### PR TITLE
Remove brainglobe-utils dependency that we don't need nor use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "brainglobe-space >= 1.0.0",
-    "brainglobe-utils >= 0.4.0",
     "click",
     "loguru",
     "meshio",


### PR DESCRIPTION
The `brainglobe-utils` dependency that we don't need slipped through the cracks. `conda-forge` complains about this.

A quick patch release (v2.0.1) will need to be made when this is merged.

