### PR TITLE
testing and fixing outdated atlas generation scripts

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/admba_3d_dev_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/admba_3d_dev_mouse.py
@@ -12,7 +12,10 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 from rich.progress import track
+
+######## I had to manually install this
 from skimage import io
+########
 
 from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
@@ -227,7 +230,7 @@ def create_atlas(
         working_dir = Path(working_dir)
     # Generated atlas path:
     working_dir = (
-        working_dir / "brainglobe_workingdir" / atlas_config.atlas_name
+        working_dir / "admba_3d_dev_mouse" / atlas_config.atlas_name
     )
     working_dir.mkdir(exist_ok=True, parents=True)
 

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/admba_3d_dev_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/admba_3d_dev_mouse.py
@@ -15,8 +15,8 @@ from rich.progress import track
 
 ######## I had to manually install this
 from skimage import io
-########
 
+########
 from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     Region,
@@ -229,9 +229,7 @@ def create_atlas(
     if isinstance(working_dir, str):
         working_dir = Path(working_dir)
     # Generated atlas path:
-    working_dir = (
-        working_dir / "admba_3d_dev_mouse" / atlas_config.atlas_name
-    )
+    working_dir = working_dir / "admba_3d_dev_mouse" / atlas_config.atlas_name
     working_dir.mkdir(exist_ok=True, parents=True)
 
     download_dir_path = working_dir / "downloads"

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/admba_3d_dev_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/admba_3d_dev_mouse.py
@@ -14,7 +14,6 @@ import pandas as pd
 from rich.progress import track
 from skimage import io
 
-########
 from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     Region,

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/admba_3d_dev_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/admba_3d_dev_mouse.py
@@ -12,8 +12,6 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 from rich.progress import track
-
-######## I had to manually install this
 from skimage import io
 
 ########

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_cord.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_cord.py
@@ -221,10 +221,7 @@ def create_atlas(working_dir):
     ORIENTATION = "asr"
     RESOLUTION = (20, 10, 10)
     ROOT_ID = 250
-    ATLAS_FILE_URL = (
-        "https://md-datasets-cache-zipfiles-prod.s3.eu-west-1."
-        "amazonaws.com/4rrggzv5d5-1.zip"
-    )
+    ATLAS_FILE_URL = "https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/4rrggzv5d5-1.zip"
     ATLAS_PACKAGER = "MetaCell LLC, Ltd."
 
     download_dir_path = working_dir / "downloads"

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/humanatlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/humanatlas.py
@@ -8,6 +8,8 @@ import pandas as pd
 import treelib
 import urllib3
 from allensdk.core.structure_tree import StructureTree
+
+### I had to install manually
 from brainio import brainio
 from rich.progress import track
 

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/humanatlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/humanatlas.py
@@ -8,8 +8,6 @@ import pandas as pd
 import treelib
 import urllib3
 from allensdk.core.structure_tree import StructureTree
-
-### I had to install manually
 from brainio import brainio
 from rich.progress import track
 

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_developmental_ccf_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_developmental_ccf_mouse.py
@@ -133,8 +133,10 @@ def create_atlas(
     df = pd.read_csv(structures_file)
     clean_up_df_entries(df)
 
-    df.loc[len(df)] = ["root", ROOT_ID, "root", ROOT_ID]
-    df.append(["root", ROOT_ID, "root", ROOT_ID])
+    new_row = pd.DataFrame(
+        [["root", ROOT_ID, "root", ROOT_ID]], columns=df.columns
+    )
+    df = pd.concat([df, new_row], ignore_index=True)
 
     id_dict = dict(zip(df["ID"], df["Parent ID"]))
 

--- a/brainglobe_atlasapi/atlas_generation/mesh_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/mesh_utils.py
@@ -158,7 +158,7 @@ def extract_mesh_from_mask(
         mesh = mesh.extractLargestRegion()
 
     # decimate
-    mesh.decimate(decimate_fraction, method="pro")
+    mesh.decimate_pro(decimate_fraction)
 
     if smooth:
         mesh.smoothLaplacian()

--- a/brainglobe_atlasapi/atlas_generation/mesh_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/mesh_utils.py
@@ -161,7 +161,7 @@ def extract_mesh_from_mask(
     mesh.decimate_pro(decimate_fraction)
 
     if smooth:
-        mesh.smoothLaplacian()
+        mesh.smooth()
 
     if obj_filepath is not None:
         write(mesh, str(obj_filepath))

--- a/brainglobe_atlasapi/atlas_generation/volume_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/volume_utils.py
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
 import os
 
 ######## I had to manually install this
-import imio
+import brainglobe_utils.image_io as image_io
 
 ########
 import numpy as np
@@ -88,7 +88,7 @@ def load_labelled_volume(data, vmin=0, alpha=1, **kwargs):
             raise FileNotFoundError(f"Volume data file {data} not found")
 
         try:
-            data = imio.load_any(data)
+            data = image_io.load_any(data)
         except Exception as e:
             raise ValueError(
                 f"Could not load volume data from file: {data} - {e}"

--- a/brainglobe_atlasapi/atlas_generation/volume_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/volume_utils.py
@@ -16,6 +16,7 @@ import os
 
 ######## I had to manually install this
 import imio
+
 ########
 import numpy as np
 

--- a/brainglobe_atlasapi/atlas_generation/volume_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/volume_utils.py
@@ -14,10 +14,7 @@ except ModuleNotFoundError:
 
 import os
 
-######## I had to manually install this
 import brainglobe_utils.image_io as image_io
-
-########
 import numpy as np
 
 

--- a/brainglobe_atlasapi/atlas_generation/volume_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/volume_utils.py
@@ -14,7 +14,9 @@ except ModuleNotFoundError:
 
 import os
 
+######## I had to manually install this
 import imio
+########
 import numpy as np
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
     "treelib",
     "vedo",
     "xmltodict",
+    "scikit-image",
+    "brainio",
+    "brainglobe-utils",
+
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Description

We want to test if the atlas validation functions pass after regenerating atlases (see: #201).
Currently, the atlas generation scripts are outdated, so to regenerate the atlases, first, we need to fix and tidy the scripts.  

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We need an up-to-date version of the atlas generation scripts and the atlases.

**What does this PR do?**

Fixes syntax errors, and removes outdated packages.

## References

#201

## How has this PR been tested?

It's just a draft PR so far

## Is this a breaking change?

It might be, due to changes in `vedo` syntax and function arguments.

## Does this PR require an update to the documentation?

Yes

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
