### PR TITLE
Fixing princeton_mouse atlas mesh

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/princeton_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/princeton_mouse.py
@@ -127,9 +127,9 @@ def create_atlas(working_dir, resolution):
     meshes_dir_path.mkdir(exist_ok=True)
 
     tree = get_structures_tree(structs_dict)
-    rotated_annotations = np.rot90(annotated_volume, axes=(0, 2))
+    # rotated_annotations = np.rot90(annotated_volume, axes=(0, 2))
 
-    labels = np.unique(rotated_annotations).astype(np.int32)
+    labels = np.unique(annotated_volume).astype(np.int32)
     for key, node in tree.nodes.items():
         if key in labels:
             is_label = True
@@ -153,7 +153,7 @@ def create_atlas(working_dir, resolution):
                         node,
                         tree,
                         labels,
-                        rotated_annotations,
+                        annotated_volume,
                         ROOT_ID,
                         closing_n_iters,
                         decimate_fraction,
@@ -177,7 +177,7 @@ def create_atlas(working_dir, resolution):
                     node,
                     tree,
                     labels,
-                    rotated_annotations,
+                    annotated_volume,
                     ROOT_ID,
                     closing_n_iters,
                     decimate_fraction,

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/princeton_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/princeton_mouse.py
@@ -127,7 +127,6 @@ def create_atlas(working_dir, resolution):
     meshes_dir_path.mkdir(exist_ok=True)
 
     tree = get_structures_tree(structs_dict)
-    # rotated_annotations = np.rot90(annotated_volume, axes=(0, 2))
 
     labels = np.unique(annotated_volume).astype(np.int32)
     for key, node in tree.nodes.items():

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/princeton_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/princeton_mouse.py
@@ -232,6 +232,7 @@ def create_atlas(working_dir, resolution):
         hemispheres_stack=None,
         cleanup_files=False,
         compress=True,
+        scale_meshes=True,
     )
 
     return output_filename


### PR DESCRIPTION
## Description

The size and orientation of the `princeton_mouse_20um` atlas mesh are incorrect. This PR fixes it. 


**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

## References

fixes #251 

## How has this PR been tested?

- regenerating the atlas
- running validation functions
- visual check in `Napari`

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
