### PR TITLE
fix metadata key

### DIFF
--- a/brainglobe_atlasapi/__init__.py
+++ b/brainglobe_atlasapi/__init__.py
@@ -2,7 +2,7 @@ from importlib.metadata import PackageNotFoundError, metadata
 
 try:
     __version__ = metadata("brainglobe-atlasapi")["Version"]
-    __author__ = metadata("brainglobe-atlasapi")["Author"]
+    __author__ = metadata("brainglobe-atlasapi")["Author-email"]
     del metadata
 except PackageNotFoundError:
     # package is not installed


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
`metadata("brainglobe-atlasapi")["Author"]` was previously returning `None` because the key does not exist

**What does this PR do?**
Replaces the `metadata` key with "Author-email" key, which does exist in the package metadata.

## References

Closes #254 

## How has this PR been tested?
Local installation of this fixes the `brainglobe-utils` tests run in an environment with both `[dev]` and `[napari]` optional dependencies install.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
