### PR TITLE
add two simple additional validation functions

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -125,7 +125,7 @@ def validate_image_dimensions(atlas: BrainGlobeAtlas):
 
 def validate_additional_references(atlas: BrainGlobeAtlas):
     """
-    Check that additional references are different, but have same dimensions
+    Check that additional references are different, but have same dimensions.
     """
     for (
         additional_reference_name

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -115,9 +115,11 @@ def validate_image_dimensions(atlas: BrainGlobeAtlas):
     """
     Check that annotation and reference image have the same dimensions.
     """
-    assert atlas.annotation.shape == atlas.reference.shape, \
-        "Annotation and reference image do not have the same dimensions."
+    assert (
+        atlas.annotation.shape == atlas.reference.shape
+    ), "Annotation and reference image do not have the same dimensions."
     return True
+
 
 def validate_additional_references(atlas: BrainGlobeAtlas):
     """
@@ -125,10 +127,12 @@ def validate_additional_references(atlas: BrainGlobeAtlas):
     """
     if atlas.additional_references:
         for additional_reference in atlas.additional_references:
-            assert additional_reference.shape == atlas.reference.shape, \
-                "Additional reference has unexpected dimension."
-            assert not np.all(additional_reference==atlas.reference), \
-                "Additional reference is not different to main reference."
+            assert (
+                additional_reference.shape == atlas.reference.shape
+            ), "Additional reference has unexpected dimension."
+            assert not np.all(
+                additional_reference == atlas.reference
+            ), "Additional reference is not different to main reference."
     return True
 
 

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -117,7 +117,7 @@ def validate_image_dimensions(atlas: BrainGlobeAtlas):
     """
     if atlas.annotation.shape != atlas.reference.shape:
         raise ValueError(
-            "Annotation and reference image do not have the same dimensions. \n"
+            "Annotation and reference image have different dimensions. \n"
             f"Annotation image has dimension: {atlas.annotation.shape}, "
             f"while reference image has dimension {atlas.reference.shape}."
         )

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -115,12 +115,10 @@ def validate_image_dimensions(atlas: BrainGlobeAtlas):
     """
     Check that annotation and reference image have the same dimensions.
     """
-    if atlas.annotation.shape != atlas.reference.shape:
-        raise ValueError(
-            "Annotation and reference image have different dimensions. \n"
-            f"Annotation image has dimension: {atlas.annotation.shape}, "
+    assert atlas.annotation.shape == atlas.reference.shape, \
+            "Annotation and reference image have different dimensions. \n"\
+            f"Annotation image has dimension: {atlas.annotation.shape}, "\
             f"while reference image has dimension {atlas.reference.shape}."
-        )
     return True
 
 

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -115,10 +115,11 @@ def validate_image_dimensions(atlas: BrainGlobeAtlas):
     """
     Check that annotation and reference image have the same dimensions.
     """
-    assert atlas.annotation.shape == atlas.reference.shape, \
-            "Annotation and reference image have different dimensions. \n"\
-            f"Annotation image has dimension: {atlas.annotation.shape}, "\
-            f"while reference image has dimension {atlas.reference.shape}."
+    assert atlas.annotation.shape == atlas.reference.shape, (
+        "Annotation and reference image have different dimensions. \n"
+        f"Annotation image has dimension: {atlas.annotation.shape}, "
+        f"while reference image has dimension {atlas.reference.shape}."
+    )
     return True
 
 

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -111,9 +111,25 @@ def validate_checksum(atlas: BrainGlobeAtlas):
     pass
 
 
-def check_additional_references(atlas: BrainGlobeAtlas):
-    # check additional references are different, but have same dimensions
-    pass
+def validate_image_dimensions(atlas: BrainGlobeAtlas):
+    """
+    Check that annotation and reference image have the same dimensions.
+    """
+    assert atlas.annotation.shape == atlas.reference.shape, \
+        "Annotation and reference image do not have the same dimensions."
+    return True
+
+def validate_additional_references(atlas: BrainGlobeAtlas):
+    """
+    Check that additional references are different, but have same dimensions
+    """
+    if atlas.additional_references:
+        for additional_reference in atlas.additional_references:
+            assert additional_reference.shape == atlas.reference.shape, \
+                "Additional reference has unexpected dimension."
+            assert not np.all(additional_reference==atlas.reference), \
+                "Additional reference is not different to main reference."
+    return True
 
 
 def catch_missing_mesh_files(atlas: BrainGlobeAtlas):
@@ -211,7 +227,8 @@ if __name__ == "__main__":
         validate_mesh_matches_image_extents,
         open_for_visual_check,
         validate_checksum,
-        check_additional_references,
+        validate_image_dimensions,
+        validate_additional_references,
         catch_missing_mesh_files,
         catch_missing_structures,
     ]

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -115,9 +115,12 @@ def validate_image_dimensions(atlas: BrainGlobeAtlas):
     """
     Check that annotation and reference image have the same dimensions.
     """
-    assert (
-        atlas.annotation.shape == atlas.reference.shape
-    ), "Annotation and reference image do not have the same dimensions."
+    if atlas.annotation.shape != atlas.reference.shape:
+        raise ValueError(
+            "Annotation and reference image do not have the same dimensions. \n"
+            f"Annotation image has dimension: {atlas.annotation.shape}, "
+            f"while reference image has dimension {atlas.reference.shape}."
+        )
     return True
 
 

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -127,14 +127,19 @@ def validate_additional_references(atlas: BrainGlobeAtlas):
     """
     Check that additional references are different, but have same dimensions
     """
-    if atlas.additional_references:
-        for additional_reference in atlas.additional_references:
-            assert (
-                additional_reference.shape == atlas.reference.shape
-            ), "Additional reference has unexpected dimension."
-            assert not np.all(
-                additional_reference == atlas.reference
-            ), "Additional reference is not different to main reference."
+    for (
+        additional_reference_name
+    ) in atlas.additional_references.references_list:
+        additional_reference = atlas.additional_references[
+            additional_reference_name
+        ]
+        assert additional_reference.shape == atlas.reference.shape, (
+            f"Additional reference {additional_reference} "
+            "has unexpected dimension."
+        )
+        assert not np.all(
+            additional_reference == atlas.reference
+        ), "Additional reference is not different to main reference."
     return True
 
 

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -10,9 +10,8 @@ from brainglobe_atlasapi.atlas_generation.validate_atlases import (
     catch_missing_mesh_files,
     catch_missing_structures,
     validate_atlas_files,
-    validate_mesh_matches_image_extents,
     validate_image_dimensions,
-    validate_additional_references
+    validate_mesh_matches_image_extents,
 )
 from brainglobe_atlasapi.config import get_brainglobe_dir
 
@@ -38,23 +37,27 @@ def atlas_with_bad_reference_file():
     yield BrainGlobeAtlas("allen_mouse_100um")
     os.rename(bad_name, good_name)
 
+
 @pytest.fixture
 def atlas_with_bad_reference_tiff_content():
     """A fixture providing an invalid version of Allen Mouse atlas for testing.
     The atlas will have a misnamed template file that won't be found by the API
     This fixture also does the clean-up after the test has run
     """
-    BrainGlobeAtlas("allen_mouse_100um") # ensure atlas is locally downloaded
-    actual_name = get_brainglobe_dir() / "allen_mouse_100um_v1.2/reference.tiff"
+    BrainGlobeAtlas("allen_mouse_100um")  # ensure atlas is locally downloaded
+    actual_name = (
+        get_brainglobe_dir() / "allen_mouse_100um_v1.2/reference.tiff"
+    )
     backup_name = (
         get_brainglobe_dir() / "allen_mouse_100um_v1.2/reference_backup.tiff"
     )
     os.rename(actual_name, backup_name)
-    too_small_reference = np.ones((3,3,3), dtype=np.uint16)
+    too_small_reference = np.ones((3, 3, 3), dtype=np.uint16)
     tifffile.imwrite(actual_name, too_small_reference)
     yield BrainGlobeAtlas("allen_mouse_100um")
     os.remove(actual_name)
     os.rename(backup_name, actual_name)
+
 
 @pytest.fixture
 def atlas_with_missing_structure():
@@ -146,8 +149,12 @@ def test_catch_missing_structures(atlas_with_missing_structure):
 def test_atlas_image_dimensions_match(atlas):
     assert validate_image_dimensions(atlas)
 
-def test_atlas_image_dimensions_match_negative(atlas_with_bad_reference_tiff_content):
+
+def test_atlas_image_dimensions_match_negative(
+    atlas_with_bad_reference_tiff_content,
+):
     with pytest.raises(
-        AssertionError, match="Annotation and reference image do not have the same dimensions"
+        AssertionError,
+        match="Annotation and reference image do not have the same dimensions",
     ):
         validate_image_dimensions(atlas_with_bad_reference_tiff_content)

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -44,7 +44,7 @@ def atlas_with_bad_reference_file():
 def atlas_with_bad_reference_tiff_content():
     """A fixture providing an invalid version of Allen Mouse atlas for testing.
     The atlas will have a misnamed template file that won't be found by the API
-    This fixture also does the clean-up after the test has run
+    This fixture cleans up the invalid atlas after the test has run.
     """
     BrainGlobeAtlas("allen_mouse_100um")  # ensure atlas is locally downloaded
     actual_name = (
@@ -77,7 +77,7 @@ def atlas_with_valid_additional_reference():
     """A fixture providing a testing-only version of the Allen Mouse atlas.
     The instance of the atlas returned has an additional reference
     consisting of an array of 1, of the correct size.
-    This fixture also does the clean-up after the test has run.
+    This fixture cleans up the invalid atlas after the test has run.
     """
     allen_100 = BrainGlobeAtlas(
         "allen_mouse_100um"
@@ -101,7 +101,7 @@ def atlas_with_reference_matching_additional_reference():
     """A fixture providing an invalid version of Allen Mouse atlas for testing.
     It provides the atlas, with an additional reference containing
     the same data as the main reference image.
-    This fixture also does the clean-up after the test has run.
+    This fixture cleans up the invalid atlas after the test has run.
     """
     allen_100 = BrainGlobeAtlas(
         "allen_mouse_100um"

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -155,6 +155,6 @@ def test_atlas_image_dimensions_match_negative(
 ):
     with pytest.raises(
         AssertionError,
-        match="Annotation and reference image do not have the same dimensions",
+        match="Annotation and reference image have different dimensions",
     ):
         validate_image_dimensions(atlas_with_bad_reference_tiff_content)

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -84,7 +84,7 @@ def atlas_with_valid_additional_reference():
     )  # ensure atlas is locally downloaded
     additional_reference_name = (
         get_brainglobe_dir()
-        / "allen_mouse_100um_v1.2/additional_reference.tiff"
+        / "allen_mouse_100um_v1.2/mock_additional_reference.tiff"
     )
     additional_reference = np.ones(allen_100.reference.shape, dtype=np.uint16)
     allen_100.additional_references = AdditionalRefDict(

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -197,12 +197,15 @@ def test_catch_missing_structures(atlas_with_missing_structure):
 
 
 def test_atlas_image_dimensions_match(atlas):
+    """Check the atlas passes the annotation-reference dimension validation"""
     assert validate_image_dimensions(atlas)
 
 
 def test_atlas_image_dimensions_match_negative(
     atlas_with_bad_reference_tiff_content,
 ):
+    """Checks that an atlas with different annotation and reference
+    dimensions is flagged by the validation."""
     with pytest.raises(
         AssertionError,
         match=r"Annotation and reference image have different dimensions.*",
@@ -213,12 +216,16 @@ def test_atlas_image_dimensions_match_negative(
 def test_atlas_additional_reference_different(
     atlas_with_valid_additional_reference,
 ):
+    """Checks that an atlas with a reasonably sized additional reference
+    passes its validation."""
     validate_additional_references(atlas_with_valid_additional_reference)
 
 
 def test_atlas_additional_reference_same(
     atlas_with_reference_matching_additional_reference,
 ):
+    """Checks that an atlas with a rduplicate additional reference
+    fails the validation for this case."""
     with pytest.raises(
         AssertionError,
         match=r"Additional reference is not different to main reference.",

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -155,6 +155,6 @@ def test_atlas_image_dimensions_match_negative(
 ):
     with pytest.raises(
         AssertionError,
-        match="Annotation and reference image have different dimensions",
+        match=r"Annotation and reference image have different dimensions.*",
     ):
         validate_image_dimensions(atlas_with_bad_reference_tiff_content)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
No validation is currently performed on the contents of the annotation or the reference images.

**What does this PR do?**
This PR adds
- a validation function that ensures mismatches between annotation and reference image size are flagged
- a validation function that flags if reference and additional reference images contains the same data (see #230 for a real-life example where this happened)
- tests for both these validation functions, and fixtures mocking the failing situations.

## References

Closes #207
Should flag #230

## How has this PR been tested?

Tests added for new functionality, tests pass locally and on CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

API docstrings added for both functions and tests.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
