### PR TITLE
restore entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ dev = [
 
 allenmouse = ["allensdk"]
 
+
+[project.scripts]
+brainglobe = "brainglobe_atlasapi.cli:bg_cli"
+
 [build-system]
 requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We lost the `brainglobe` CLI entry point since 2.0.0

**What does this PR do?**
Restores the entry point.

## References

Closes #263 

## How has this PR been tested?

Local testing with `which brainglobe` and `brainglobe update -a princeton_mouse_20um` with newly updated version of atlas (see #251 )

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
