### PR TITLE
Fixes to Perens and Kim mouse atlases

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
@@ -117,9 +117,7 @@ def create_atlas(working_dir, resolution):
 
     tree = get_structures_tree(structures)
 
-    rotated_annotations = np.rot90(annotated_volume, axes=(0, 2))
-
-    labels = np.unique(rotated_annotations).astype(np.int32)
+    labels = np.unique(annotated_volume).astype(np.int32)
     for key, node in tree.nodes.items():
         if key in labels:
             is_label = True
@@ -146,7 +144,7 @@ def create_atlas(working_dir, resolution):
                         node,
                         tree,
                         labels,
-                        rotated_annotations,
+                        annotated_volume,
                         ROOT_ID,
                         closing_n_iters,
                         decimate_fraction,
@@ -170,7 +168,7 @@ def create_atlas(working_dir, resolution):
                     node,
                     tree,
                     labels,
-                    rotated_annotations,
+                    annotated_volume,
                     ROOT_ID,
                     closing_n_iters,
                     decimate_fraction,

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
@@ -24,7 +24,7 @@ from brainglobe_atlasapi.atlas_generation.mesh_utils import (
 from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
 from brainglobe_atlasapi.structure_tree_util import get_structures_tree
 
-PARALLEL = True  # disable parallel mesh extraction for easier debugging
+PARALLEL = False # disable parallel mesh extraction for easier debugging
 
 
 def create_atlas(working_dir, resolution):

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
@@ -24,7 +24,7 @@ from brainglobe_atlasapi.atlas_generation.mesh_utils import (
 from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
 from brainglobe_atlasapi.structure_tree_util import get_structures_tree
 
-PARALLEL = False # disable parallel mesh extraction for easier debugging
+PARALLEL = False  # disable parallel mesh extraction for easier debugging
 
 
 def create_atlas(working_dir, resolution):

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
@@ -1,5 +1,6 @@
 __version__ = "1"
 
+import argparse
 import json
 import multiprocessing as mp
 import tarfile
@@ -23,7 +24,7 @@ from brainglobe_atlasapi.atlas_generation.mesh_utils import (
 from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
 from brainglobe_atlasapi.structure_tree_util import get_structures_tree
 
-PARALLEL = False  # disable parallel mesh extraction for easier debugging
+PARALLEL = True  # disable parallel mesh extraction for easier debugging
 
 
 def create_atlas(working_dir, resolution):
@@ -235,9 +236,21 @@ def create_atlas(working_dir, resolution):
 
 
 if __name__ == "__main__":
-    resolution = 10  # some resolution, in microns (10, 25, 50, 100)
+    # Create argument parser to pass resoulution as an argument
+    parser = argparse.ArgumentParser(
+        description="Create an atlas with a specified resolution."
+    )
+    parser.add_argument(
+        "--resolution",
+        type=int,
+        default=10,
+        help="Resolution in microns (10, 25, 50, 100)",
+    )
+    args = parser.parse_args()
 
     # Generated atlas path:
     bg_root_dir = Path.home() / "brainglobe_workingdir" / "kim_mouse"
     bg_root_dir.mkdir(exist_ok=True, parents=True)
-    create_atlas(bg_root_dir, resolution)
+
+    # Use the parsed resolution
+    create_atlas(bg_root_dir, args.resolution)

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
@@ -248,8 +248,9 @@ def create_atlas(working_dir, resolution):
         node.data = Region(is_label)
 
     # Mesh creation
-    closing_n_iters = 2
-    decimate_fraction = 0.2
+    closing_n_iters = 2  # not used for this atlas
+    decimate_fraction = 0.2  # not used for this atlas
+
     smooth = False
     start = time.time()
     if PARALLEL:

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
@@ -249,6 +249,8 @@ def create_atlas(working_dir, resolution):
 
     # Mesh creation
     closing_n_iters = 2
+    decimate_fraction = 0.2
+    smooth = False
     start = time.time()
     if PARALLEL:
         pool = mp.Pool(mp.cpu_count() - 2)
@@ -265,6 +267,8 @@ def create_atlas(working_dir, resolution):
                         annotated_volume,
                         ROOT_ID,
                         closing_n_iters,
+                        decimate_fraction,
+                        smooth,
                     )
                     for node in tree.nodes.values()
                 ],

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
@@ -291,6 +291,8 @@ def create_atlas(working_dir, resolution):
                     annotated_volume,
                     ROOT_ID,
                     closing_n_iters,
+                    decimate_fraction,
+                    smooth,
                 )
             )
 

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
@@ -145,7 +145,7 @@ def create_atlas(working_dir, resolution):
     SPECIES = "Mus musculus"
     ATLAS_LINK = "https://github.com/Gubra-ApS/LSFM-mouse-brain-atlas"
     CITATION = "Perens et al. 2021, https://doi.org/10.1007/s12021-020-09490-8"
-    ORIENTATION = "rai"
+    ORIENTATION = "asr"
     ROOT_ID = 997
     ATLAS_FILE_URL = "https://github.com/Gubra-ApS/LSFM-mouse-brain-atlas/archive/master.tar.gz"
 

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
@@ -20,7 +20,7 @@ from brainglobe_atlasapi.atlas_generation.mesh_utils import (
 from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
 from brainglobe_atlasapi.structure_tree_util import get_structures_tree
 
-PARALLEL = False  # disable parallel mesh extraction for easier debugging
+PARALLEL = True  # disable parallel mesh extraction for easier debugging
 
 
 ### Additional functions #####################################################


### PR DESCRIPTION
## Description

This PR fixes `IndexError: tuple index out of range` of `perens_lsfm_mouse.py` (see: #249) and the orientation and scaling issue of perens_lsfm_moue and kim_mouse atlases mentioned in #265

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**What does this PR do?**

fixes #265 

## References

#265

## How has this PR been tested?

tested on HPC and locally

## Is this a breaking change?

no

## Does this PR require an update to the documentation?

Yes, when new versions of the atlases are published

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
