### PR TITLE
Update use of brainio to brainglobe-utils

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/humanatlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/humanatlas.py
@@ -8,11 +8,9 @@ import pandas as pd
 import treelib
 import urllib3
 from allensdk.core.structure_tree import StructureTree
-from brainio import brainio
+from brainglobe_utils.IO.image.load import load_any
 from rich.progress import track
 
-# import sys
-# sys.path.append("./")
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     Region,
     create_region_mesh,
@@ -99,8 +97,8 @@ if __name__ == "__main__":
     # ---------------- #
     #   GET TEMPLATE   #
     # ---------------- #
-    annotation = brainio.load_any(annotations_image)  # shape (394, 466, 378)
-    anatomy = brainio.load_any(anatomy_image)  # shape (394, 466, 378)
+    annotation = load_any(annotations_image)  # shape (394, 466, 378)
+    anatomy = load_any(anatomy_image)  # shape (394, 466, 378)
 
     # Remove weird artefact
     annotation = annotation[:200, :, :]

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/kim_mouse.py
@@ -14,8 +14,6 @@ from allensdk.core.reference_space_cache import ReferenceSpaceCache
 from rich.progress import track
 from scipy.ndimage import zoom
 
-# import sys
-# sys.path.append("./")
 from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     Region,

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/perens_lsfm_mouse.py
@@ -11,7 +11,6 @@ import pandas as pd
 import SimpleITK as sitk
 from rich.progress import track
 
-# from allensdk.core.reference_space_cache import ReferenceSpaceCache
 from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     Region,


### PR DESCRIPTION
This PR updates the data loading code in this repo to correspond to the changes in https://github.com/brainglobe/brainglobe-utils/pull/73. I also removed some commented out code.

Tests should pass even without https://github.com/brainglobe/brainglobe-utils/pull/73 being merged because we don't test the atlas generation code. 