### PR TITLE
Return `brainglobe list` in alphabetical order

### DIFF
--- a/brainglobe_atlasapi/cli.py
+++ b/brainglobe_atlasapi/cli.py
@@ -23,7 +23,7 @@ def bg_cli(
     ----------
     command: str. Name of the command:
         - list: list available atlases
-        - install: isntall new atlas
+        - install: install new atlas
         - update: update an installed atlas
         - config: modify config
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
When running `brainglobe list`, the resulting table isn't in alphabetical order. and it looks a bit scruffy.

**What does this PR do?**
This PR orders the table. The downloaded and not downloaded atlases are sorted independently, so the downloaded atlases are always at the top. It also refactors the file a bit and fixes a typo.

## References

Closes #292

## How has this PR been tested?

Tested manually, and existing tests pass.


