### PR TITLE
Return "Outside atlas" rather than key error

### DIFF
--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -179,7 +179,7 @@ class Atlas:
         microns=False,
         as_acronym=False,
         hierarchy_lev=None,
-        key_error_string="Out of brain",
+        key_error_string="Outside atlas",
     ):
         """Get the structure from a coordinate triplet.
 
@@ -191,7 +191,8 @@ class Atlas:
             If true, coordinates are interpreted in microns.
         as_acronym : bool
             If true, the region acronym is returned.
-            If out of brain (structure gives key error), return "Out of brain"
+            If outside atlas (structure gives key error),
+            return "Outside atlas"
         hierarchy_lev : int or None
             If specified, return parent node at thi hierarchy level.
 

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -174,7 +174,12 @@ class Atlas:
         return hem
 
     def structure_from_coords(
-        self, coords, microns=False, as_acronym=False, hierarchy_lev=None
+        self,
+        coords,
+        microns=False,
+        as_acronym=False,
+        hierarchy_lev=None,
+        key_error_string="Out of brain",
     ):
         """Get the structure from a coordinate triplet.
 
@@ -186,6 +191,7 @@ class Atlas:
             If true, coordinates are interpreted in microns.
         as_acronym : bool
             If true, the region acronym is returned.
+            If out of brain (structure gives key error), return "Out of brain"
         hierarchy_lev : int or None
             If specified, return parent node at thi hierarchy level.
 
@@ -202,8 +208,11 @@ class Atlas:
             rid = self.structures[rid]["structure_id_path"][hierarchy_lev]
 
         if as_acronym:
-            d = self.structures[rid]
-            return d["acronym"]
+            try:
+                d = self.structures[rid]
+                return d["acronym"]
+            except KeyError:
+                return key_error_string
         else:
             return rid
 

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -102,6 +102,19 @@ def test_data_from_coords(atlas, coords):
     )
 
 
+def test_data_from_coords_out_of_brain(atlas, coords=(1, 1, 1)):
+    assert atlas.structure_from_coords(coords) == 0
+    assert atlas.structure_from_coords(coords, microns=True) == 0
+
+    assert (
+        atlas.structure_from_coords(coords, as_acronym=True) == "Out of brain"
+    )
+    assert (
+        atlas.structure_from_coords(coords, microns=True, as_acronym=True)
+        == "Out of brain"
+    )
+
+
 def test_meshfile_from_id(atlas):
     assert (
         atlas.meshfile_from_structure("CH")

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -102,16 +102,19 @@ def test_data_from_coords(atlas, coords):
     )
 
 
-def test_data_from_coords_out_of_brain(atlas, coords=(1, 1, 1)):
+def test_data_from_coords_out_of_brain(
+    atlas, coords=(1, 1, 1), key_error_string="Outside atlas"
+):
     assert atlas.structure_from_coords(coords) == 0
     assert atlas.structure_from_coords(coords, microns=True) == 0
 
     assert (
-        atlas.structure_from_coords(coords, as_acronym=True) == "Out of brain"
+        atlas.structure_from_coords(coords, as_acronym=True)
+        == key_error_string
     )
     assert (
         atlas.structure_from_coords(coords, microns=True, as_acronym=True)
-        == "Out of brain"
+        == key_error_string
     )
 
 

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -103,8 +103,11 @@ def test_data_from_coords(atlas, coords):
 
 
 def test_data_from_coords_out_of_brain(
-    atlas, coords=(1, 1, 1), key_error_string="Outside atlas"
+    atlas,
 ):
+    coords = (1, 1, 1)
+    key_error_string = "Outside atlas"
+
     assert atlas.structure_from_coords(coords) == 0
     assert atlas.structure_from_coords(coords, microns=True) == 0
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
When querying for structures as ID from coordinates, out of bounds coordinates return 0, but when asking for an acronym, it raises a KeyError value.

**What does this PR do?**
Rather than a key error, "Outside atlas" is returned

## References

Closes #157

## How has this PR been tested?

New tests added & checked manually

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?

Don't think so

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
