### PR TITLE
Remove slow test marker

### DIFF
--- a/tests/atlasapi/test_config_file.py
+++ b/tests/atlasapi/test_config_file.py
@@ -26,33 +26,33 @@ def test_config_creation(conf_path):
             assert val == str(config.TEMPLATE_CONF_DICT[sectname][k])
 
 
-# Ugly test zone: here we use the terminal commands, which edit the config
-# file in the brainglobe_atlasapi repo from which the tests are being run.
-# This is not the cleanest way, the alternative would be to run this test in
-# a new env.
-@pytest.mark.slow
-def test_config_edit():
+def test_config_edit(tmp_path):
+    # Create a CliRunner instance
     runner = CliRunner()
     result = runner.invoke(cli.bg_cli, ["config", "--show"])
+
+    # Assert the command ran successfully
     assert result.exit_code == 0
     assert result.output == config._print_config() + "\n"
 
+    # Read the current config
     config_pre = config.read_config()
     original_bg_folder = config_pre["default_dirs"]["brainglobe_dir"]
 
-    new_atlas_dir = Path(tempfile.mkdtemp())
-    config.write_config_value("brainglobe_dir", new_atlas_dir)
+    # Create a temporary directory for the new atlas directory
+    new_atlas_dir = tmp_path / "new_brainglobe_dir"
+    new_atlas_dir.mkdir()
+
+    # Replace the brainglobe_dir in the config with the temp directory
+    config.write_config_value("brainglobe_dir", str(new_atlas_dir))
     config_post = config.read_config()
 
+    # Assert that the config was updated correctly
     assert config_post["default_dirs"]["brainglobe_dir"] == str(new_atlas_dir)
 
-    # Use new location to download:
+    # Use new location to download the atlas
     atlas = bg_atlas.BrainGlobeAtlas(atlas_name="example_mouse_100um")
-
     assert atlas.root_dir.parent == new_atlas_dir
 
-    # Fix the mess:
+    # Restore the original config value
     config.write_config_value("brainglobe_dir", original_bg_folder)
-
-    # cleanup:
-    shutil.rmtree(new_atlas_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,12 +22,3 @@ def temp_path():
 @pytest.fixture(scope="module")
 def atlas_path():
     return BrainGlobeAtlas("example_mouse_100um").root_dir
-
-
-def pytest_addoption(parser):
-    parser.addoption("--runslow", action="store_true", help="run slow tests")
-
-
-def pytest_runtest_setup(item):
-    if "slow" in item.keywords and not item.config.getvalue("runslow"):
-        pytest.skip("need --runslow option to run")


### PR DESCRIPTION
This PR closes #297 by removing the slow pytest marker.

I changed the test a bit, but it's still not ideal, because it changes the default brainglobe config file. It changes it back, but that's not great.

I assumed I could get around this by setting `monkeypatch.setenv("BRAINGLOBE_CONFIG_DIR", str(tmp_path))`, this however doesn't seem to set the config dir temporarily. I don't know if I'm monkeypatching this incorrectly, or there's a bug in the atlas api itself.

I've created this as a draft PR because I think this should be fixed, but maybe this PR should be merged and then an issue created to improve the test? This PR doesn't introduce the problem. 