### PR TITLE
Move `pymcubes` to an optional dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "numpy",
     "pandas",
     "pyarrow",
-    "PyMCubes",
     "requests",
     "rich >= 9.0.0",
     "SimpleITK",
@@ -59,9 +58,8 @@ dev = [
     "setuptools_scm",
     "tox",
 ]
-
 allenmouse = ["allensdk"]
-
+atlasgen = ["PyMCubes"]
 
 [project.scripts]
 brainglobe = "brainglobe_atlasapi.cli:bg_cli"
@@ -88,7 +86,7 @@ filterwarnings = [
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
 [tool.black]
-target-version = ['py310','py311', 'py312']
+target-version = ['py310', 'py311', 'py312']
 skip-string-normalization = false
 line-length = 79
 
@@ -116,5 +114,6 @@ python =
 [testenv]
 extras =
     dev
+    atlasgen
 commands = pytest -v --color=yes --cov=brainglobe_atlasapi --cov-report=xml
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,20 +21,14 @@ requires-python = ">=3.10"
 dependencies = [
     "brainglobe-space >= 1.0.0",
     "click",
-    "loguru",
     "meshio",
     "numpy",
     "pandas",
     "pyarrow",
     "requests",
     "rich >= 9.0.0",
-    "SimpleITK",
     "tifffile",
-    "tqdm>=4.46.1",
     "treelib",
-    "vedo",
-    "xmltodict",
-    "scikit-image",
 ]
 dynamic = ["version"]
 
@@ -59,7 +53,14 @@ dev = [
     "tox",
 ]
 allenmouse = ["allensdk"]
-atlasgen = ["PyMCubes"]
+atlasgen = [
+    "loguru",
+    "PyMCubes",
+    "SimpleITK",
+    "tqdm>=4.46.1",
+    "vedo",
+    "xmltodict",
+]
 
 [project.scripts]
 brainglobe = "brainglobe_atlasapi.cli:bg_cli"


### PR DESCRIPTION
`PyMCubes` is a dependency that is only required during atlas generation, and [currently doesn't have an ARM package](https://github.com/brainglobe/brainreg/issues/206#issuecomment-2167579703) on conda-forge.

Forcing it to be a core dependency results in failed builds when installing via conda-forge, and since it's not needed for registration, we have decided to move it to an optional `atlasgen` dependency that users will not obtain by default.

After this, we'll need a new PyPI release and then to fix the corresponding conda-forge feedstock PR that will be created.