### PR TITLE
Ensure no allen_cord meshes are black

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_cord.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_cord.py
@@ -258,8 +258,11 @@ def create_atlas(working_dir):
         structures, meshes_dir_path
     )
 
-    # Set root mesh to white
-    structures_with_mesh[82]["rgb_triplet"] = [255, 255, 255]
+    # Set black meshes to white
+    for structure in structures_with_mesh:
+        if structure["rgb_triplet"] == [0, 0, 0]:
+            structure["rgb_triplet"] = [255, 255, 255]
+
     # Wrap up, compress, and remove file:
     print("Finalising atlas")
     output_filename = wrapup_atlas_from_data(

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_cord.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_cord.py
@@ -258,6 +258,8 @@ def create_atlas(working_dir):
         structures, meshes_dir_path
     )
 
+    # Set root mesh to white
+    structures_with_mesh[82]["rgb_triplet"] = [255, 255, 255]
     # Wrap up, compress, and remove file:
     print("Finalising atlas")
     output_filename = wrapup_atlas_from_data(


### PR DESCRIPTION
The updated atlas script looked fine, but some meshes were black, so they didn't show up in `brainrender-napari`. 