### PR TITLE
use capital letter of each word for axolotl main structures

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
@@ -117,10 +117,12 @@ def create_atlas(working_dir, resolution):
         element["structure_id_path"] = structure_id_path + [element["id"]]
 
     for main_structure, id_main_structure in structure_id_map.items():
-
+        main_structure_acronym = "".join(
+            [word[0].upper() for word in main_structure.split()]
+        )
         create_main_structure = {
             "name": main_structure,
-            "acronym": main_structure[0:3],
+            "acronym": main_structure_acronym,
             "id": id_main_structure,
             "rgb_triplet": [125, 0, 125],
             "structure_id_path": [ROOT_ID, id_main_structure],

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
@@ -220,7 +220,7 @@ def create_atlas(working_dir, resolution):
     # Package all the provided data and parameters into an atlas format
     output_filename = wrapup_atlas_from_data(
         atlas_name=ATLAS_NAME,
-        atlas_minor_version="1.0",
+        atlas_minor_version=__version__,
         citation=CITATION,
         atlas_link=ATLAS_LINK,
         species=SPECIES,


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The draft acronyms for higher-level ("main structure") axolotl brain regions could be nicer.

**What does this PR do?**
* Uses the first letter of all words in the higher-level region names as the acronym, as suggested by @adamltyson.
For example, "Olfactory bulb" is abbreviated `OB` and "Telencephalon" gets the acronym `T`.
* also passes the minor version `0` to the wrapup function, as this will be the first release (1.0.0) of this atlas in BrainGlobe.

## References
Closes #341 

## How has this PR been tested?

Checking that for a locally generated version of the atlas, I can make a `NapariAtlasRepresentation` and call `add_structure_to_viewer("T")` and `add_structure_to_viewer("OB")` on it, and appropriate region meshes appear in 3D. Also, manual inspection of the generated `structures.json` file.

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?

When we publish the atlas, but not right now.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

cc @saimaabdus19 