### PR TITLE
modal-filter annotations before meshing

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
@@ -10,6 +10,9 @@ import pooch
 from brainglobe_utils.IO.image import load_nii
 from rich.progress import track
 
+from skimage.morphology import ball
+from skimage.filters.rank import modal
+
 from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     Region,
@@ -163,13 +166,17 @@ def create_atlas(working_dir, resolution):
         node.data = Region(is_label)
 
     # Mesh creation parameters
-    closing_n_iters = 5
-    decimate_fraction = 0.1
+    closing_n_iters = 10
+    decimate_fraction = 0.6
     smooth = True
 
     meshes_dir_path = working_dir / "meshes"
     meshes_dir_path.mkdir(exist_ok=True)
 
+    # pass a smoothed version of the annotations for meshing
+    smoothed_annotations = annotation_image.copy()
+    smoothed_annotations = modal(smoothed_annotations.astype(np.uint8), ball(5))
+    
     # Measure duration of mesh creation
     start = time.time()
 
@@ -186,7 +193,7 @@ def create_atlas(working_dir, resolution):
                 node,
                 tree,
                 labels,
-                annotation_image,
+                smoothed_annotations,
                 ROOT_ID,
                 closing_n_iters,
                 decimate_fraction,

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
@@ -9,9 +9,8 @@ import numpy as np
 import pooch
 from brainglobe_utils.IO.image import load_nii
 from rich.progress import track
-
-from skimage.morphology import ball
 from skimage.filters.rank import modal
+from skimage.morphology import ball
 
 from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
@@ -175,8 +174,10 @@ def create_atlas(working_dir, resolution):
 
     # pass a smoothed version of the annotations for meshing
     smoothed_annotations = annotation_image.copy()
-    smoothed_annotations = modal(smoothed_annotations.astype(np.uint8), ball(5))
-    
+    smoothed_annotations = modal(
+        smoothed_annotations.astype(np.uint8), ball(5)
+    )
+
     # Measure duration of mesh creation
     start = time.time()
 

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
@@ -10,8 +10,8 @@ import pooch
 from brainglobe_utils.IO.image import load_nii
 from rich.progress import track
 from skimage.filters.rank import modal
-from skimage.morphology import ball
 from skimage.measure import label, regionprops
+from skimage.morphology import ball
 
 from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Axolotl atlas script currently creates quite rough meshes, because the annotations have a few quite jagged regions.

**What does this PR do?**

Smoothes the meshes a bit, by keeping more vertices, closing more, and importantly, passing the meshing code a modal-filtered version of the annotations.


## References

\

## How has this PR been tested?

Local visual inspections of the resulting pallium, telencephalon and root meshes:

![image](https://github.com/user-attachments/assets/1459f73c-2445-42a2-aa31-f1141dc16700)

vs before

![image](https://github.com/user-attachments/assets/4ae504f7-d3f2-4521-ba21-e0fdac92c004)

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [ \ ] Tests have been added to cover all new functionality (unit & integration)
- [ \ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
