### PR TITLE
fixed bug where progress bar didn't update properly

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -189,7 +189,7 @@ def retrieve_over_http(
                     adv = len(chunk)
                     completed += adv
                     progress.update(
-                        task_id, completed=min(completed, tot), refresh=True
+                        task_id, completed=min(completed, tot)
                     )
 
                     if fn_update:

--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -188,9 +188,7 @@ def retrieve_over_http(
                     fout.write(chunk)
                     adv = len(chunk)
                     completed += adv
-                    progress.update(
-                        task_id, completed=min(completed, tot)
-                    )
+                    progress.update(task_id, completed=min(completed, tot))
 
                     if fn_update:
                         # update handler with completed and total bytes


### PR DESCRIPTION

## Description

Fixes the progress bar bug described here https://github.com/brainglobe/brainglobe-atlasapi/issues/334

It was because refresh was true which means the progress bar had to update on every single chunk. On a fast internet connection this was way too frequently. By setting refresh to False (it's default value) the progress bar chunks its updates and updates at a sensible frequency. This solves the update issue on my machine. 
**What is this PR**

- [x ] Bug fix
- [ ] Addition of a new feature
- [ ] Other



## References

https://github.com/brainglobe/brainglobe-atlasapi/issues/334

## How has this PR been tested?

It's a very minor change however I have downloaded multiple atlases and it works. 

## Is this a breaking change?
No

## Does this PR require an update to the documentation?

No
## Checklist:

- [x ] The code has been tested locally
- [x ] Tests have been added to cover all new functionality (unit & integration)
- [ x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
 (it is changing one argument im not sure i need to run the pre-commit formatting but i can)
