### PR TITLE
Create `.brainglobe` dir if it doesn't exist when fetching atlas versions

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -307,6 +307,9 @@ def conf_from_url(url) -> configparser.ConfigParser:
     config_obj.read_string(text)
     cache_path = config.get_brainglobe_dir() / "last_versions.conf"
 
+    if not cache_path.parent.exists():
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+
     # Cache the available atlases
     with open(cache_path, "w") as f_out:
         config_obj.write(f_out)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently, if `get_atlases_last_versions` is called and the `.brainglobe` directory doesn't exist the program will throw a `FileNotFoundError`.

**What does this PR do?**
If the `.brainglobe` directory doesn't exist, create it before trying to cache `last_versions.conf` file.
