### PR TITLE
don't rerun tests on README updates

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -6,6 +6,8 @@ on:
       - "main"
     tags:
       - "v**"
+    paths-ignore:
+      - '**/README.md'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
currently the tests rerun on all pushes. Even if that push was just to update the README.
very minor change, it just bugged me seeing the tests always rerun on readme changes :) 