### PR TITLE
Make list atlas function more robust

### DIFF
--- a/brainglobe_atlasapi/list_atlases.py
+++ b/brainglobe_atlasapi/list_atlases.py
@@ -2,6 +2,8 @@
     Some functionality to list all available and downloaded brainglobe atlases
 """
 
+import re
+
 from rich import print as rprint
 from rich.panel import Panel
 from rich.table import Table
@@ -43,11 +45,15 @@ def get_local_atlas_version(atlas_name):
     """
 
     brainglobe_dir = config.get_brainglobe_dir()
-    return [
-        f.name.split("_v")[1]
-        for f in brainglobe_dir.glob(f"*{atlas_name}*")
-        if f.is_dir()
-    ][0]
+    try:
+        return [
+            re.search(r"_v(\d+\.\d+)$", f.name).group(1)
+            for f in brainglobe_dir.glob(f"*{atlas_name}*")
+            if f.is_dir() and re.search(r"_v(\d+\.\d+)$", f.name)
+        ][0]
+    except IndexError:
+        print(f"No atlas found with the name: {atlas_name}")
+        return None
 
 
 def get_all_atlases_lastversions():

--- a/tests/atlasapi/test_list_atlases.py
+++ b/tests/atlasapi/test_list_atlases.py
@@ -17,10 +17,16 @@ def test_get_downloaded_atlases():
     assert "example_mouse_100um" in available_atlases
 
 
-def test_get_local_atlas_version():
+def test_get_local_atlas_version_real_atlas():
     v = get_local_atlas_version("example_mouse_100um")
-
     assert len(v.split(".")) == 2
+
+
+def test_get_local_atlas_version_missing_atlas(capsys):
+    atlas_name = "unicorn_atlas"
+    assert get_local_atlas_version(atlas_name) is None
+    captured = capsys.readouterr()
+    assert f"No atlas found with the name: {atlas_name}" in captured.out
 
 
 def test_lastversions():


### PR DESCRIPTION
The existing function returned garbage if there was a "_v" anywhere in the atlas name (e.g. "prairie_vole"), and also didn't produce anything informative if the atlas couldn't be found. This PR makes this function more robust and adds error handling. 