### PR TITLE
Fail gracefully if cache directory is read only

### DIFF
--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -204,10 +204,14 @@ class BrainGlobeAtlas(core.Atlas):
             True if it is, and None if we are offline.
         """
 
-        if self.remote_version is None:  # in this case, we are offline
+        # Cache remote version to avoid multiple requests
+        remote_version = self.remote_version
+        # If we are offline, return None
+        if remote_version is None:
             return
+
         local = _version_str_from_tuple(self.local_version)
-        online = _version_str_from_tuple(self.remote_version)
+        online = _version_str_from_tuple(remote_version)
 
         if local != online:
             if print_warning:

--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -291,7 +291,7 @@ def get_download_size(url: str) -> int:
 
 
 def conf_from_url(url) -> configparser.ConfigParser:
-    """Read conf file from an URL. And cache a copy in the brainglobe dir.
+    """Read conf file from a URL. And cache a copy in the brainglobe dir.
     Parameters
     ----------
     url : str
@@ -305,14 +305,17 @@ def conf_from_url(url) -> configparser.ConfigParser:
     text = requests.get(url).text
     config_obj = configparser.ConfigParser()
     config_obj.read_string(text)
-    cache_path = config.get_brainglobe_dir() / "last_versions.conf"
+    cache_path: Path = config.get_brainglobe_dir() / "last_versions.conf"
 
-    if not cache_path.parent.exists():
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if not cache_path.parent.exists():
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Cache the available atlases
-    with open(cache_path, "w") as f_out:
-        config_obj.write(f_out)
+        # Cache the available atlases
+        with open(cache_path, "w") as f_out:
+            config_obj.write(f_out)
+    except OSError as e:
+        print(f"Could not update the latest atlas versions cache: {e}")
 
     return config_obj
 

--- a/tests/atlasapi/test_utils.py
+++ b/tests/atlasapi/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from unittest import mock
 
 import pytest
@@ -144,6 +145,7 @@ def test_conf_from_file_no_file(temp_path):
         assert "Last versions cache file not found." == str(e)
 
 
+@pytest.skipif(sys.platform == "win32", reason="Does not run on Windows")
 def test_conf_from_url_read_only(temp_path, mocker):
     # Test with a valid URL and a non-existing parent folder
     mocker.patch(

--- a/tests/atlasapi/test_utils.py
+++ b/tests/atlasapi/test_utils.py
@@ -163,4 +163,4 @@ def test_conf_from_url_read_only(temp_path, mocker):
     )
 
     # Set the permissions back to the original
-    os.chmod(temp_path, int(curr_mode, 8))
+    temp_path.chmod(int(curr_mode, 8))

--- a/tests/atlasapi/test_utils.py
+++ b/tests/atlasapi/test_utils.py
@@ -145,7 +145,7 @@ def test_conf_from_file_no_file(temp_path):
         assert "Last versions cache file not found." == str(e)
 
 
-@pytest.skipif(sys.platform == "win32", reason="Does not run on Windows")
+@pytest.mark.skipif(sys.platform == "win32", reason="Does not run on Windows")
 def test_conf_from_url_read_only(temp_path, mocker):
     # Test with a valid URL and a non-existing parent folder
     mocker.patch(


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
If a user doesn't have write permission to the `.brainglobe` directory, instantiating an atlas will cause a crash unless `check_latest=False` is set.

**What does this PR do?**
Gracefully handles permission denied errors when caching the `latest_versions.conf` file. The user will be informed of the error without crashes.

## References
https://github.com/brainglobe/brainglobe-heatmap/issues/65
https://github.com/brainglobe/brainrender/issues/395

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
Tested locally by changing the permissions for the `last_versions.conf` file.

New test added to check error is printed once, and `utils.conf_from_url` runs even if `.brainglobe` has read only permissions.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
