### PR TITLE
Add extra check for response code fetching last_versions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,9 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       week_number: ${{ steps.get-week-number.outputs.week_number }}
-    steps:
-      run:
-        echo "week_number=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
+    run:
+      echo "week_number=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
 
   test:
     needs: [linting, manifest]

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,6 +25,8 @@ jobs:
 
   get-week-number:
     runs-on: ubuntu-latest
+    outputs:
+        WEEK_NUMBER: ${{ steps.get-week-number.outputs.WEEK_NUMBER }}
     steps:
     - name: Get week number
       id: get-week-number

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -26,16 +26,18 @@ jobs:
   get-week-number:
     runs-on: ubuntu-latest
     outputs:
-      week_number: ${{ steps.get-week-number.outputs.week_number }}
+      week-number: ${{ steps.get-week-number.outputs.WEEK_NUMBER }}
     steps:
     - name: Get week number
       run:
-        echo "week_number=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
+        echo "WEEK_NUMBER=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
 
   test:
     needs: [linting, manifest, get-week-number]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    env:
+      WEEK_NUMBEr: ${{ needs.get-week-number.outputs.WEEK_NUMBER }}
     strategy:
       matrix:
         # Run all supported Python versions on linux
@@ -58,9 +60,9 @@ jobs:
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
           enableCrossOsArchive: 'true'
-          key: brainglobe-${{ steps.get-week-number.outputs.week_number }}
+          key: brainglobe-${{ github.env.WEEK_NUMBER }}
           restore-keys: |
-              brainglobe-${{ steps.get-week-number.outputs.week_number }}
+              brainglobe-${{ github.env.WEEK_NUMBER }}
               brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Get week number
+      id: get-week-number
       run:
         echo "WEEK_NUMBER=$(date -u "+%V")" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,19 +25,15 @@ jobs:
 
   get-week-number:
     runs-on: ubuntu-latest
-    outputs:
-      pr-number: ${{ steps.get-week-number.outputs.PR_NUMBER }}
     steps:
     - name: Get week number
       run:
-        echo "PR_NUMBER=$(date -u "+%V")" >> $GITHUB_OUTPUT
+        echo "WEEK_NUMBER=$(date -u "+%V")" >> "$GITHUB_OUTPUT"
 
   test:
     needs: [linting, manifest, get-week-number]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    env:
-      WEEK_NUMBER: ${{ needs.get-week-number.outputs.pr-number }}
     strategy:
       matrix:
         # Run all supported Python versions on linux
@@ -60,9 +56,9 @@ jobs:
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
           enableCrossOsArchive: 'true'
-          key: brainglobe-{{ $WEEK_NUMBER }}
+          key: brainglobe-${{ steps.get-week-number.outputs.WEEK_NUMBER }}
           restore-keys: |
-              brainglobe-{{ $WEEK_NUMBER }}
+              brainglobe-${{ steps.get-week-number.outputs.WEEK_NUMBER }}
               brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,8 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       week_number: ${{ steps.get-week-number.outputs.week_number }}
-    run:
-      echo "week_number=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
+    steps:
+    - name: Get week number
+      run:
+        echo "week_number=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
 
   test:
     needs: [linting, manifest]

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - uses: neuroinformatics-unit/actions/check_manifest@v2
 
+  get-week-number:
+    runs-on: ubuntu-latest
+    outputs:
+      week_number: ${{ steps.get-week-number.outputs.week_number }}
+    steps:
+      run:
+        echo "week_number=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
+
   test:
     needs: [linting, manifest]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
@@ -43,12 +51,16 @@ jobs:
 
     steps:
       - name: Cache atlases
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
-          key: brainglobe
+          enableCrossOsArchive: 'true'
+          key: brainglobe-${{ steps.get-week-number.outputs.week_number }}
+          restore-keys: |
+              brainglobe-${{ steps.get-week-number.outputs.week_number }}
+              brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,7 +37,7 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     env:
-      WEEK_NUMBEr: ${{ needs.get-week-number.outputs.WEEK_NUMBER }}
+      WEEK_NUMBER: ${{ needs.get-week-number.outputs.WEEK_NUMBER }}
     strategy:
       matrix:
         # Run all supported Python versions on linux
@@ -60,9 +60,9 @@ jobs:
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
           enableCrossOsArchive: 'true'
-          key: brainglobe-${{ github.env.WEEK_NUMBER }}
+          key: brainglobe-$WEEK_NUMBER
           restore-keys: |
-              brainglobe-${{ github.env.WEEK_NUMBER }}
+              brainglobe-$WEEK_NUMBER
               brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -26,18 +26,18 @@ jobs:
   get-week-number:
     runs-on: ubuntu-latest
     outputs:
-      week-number: ${{ steps.get-week-number.outputs.WEEK_NUMBER }}
+      pr-number: ${{ steps.get-week-number.outputs.PR_NUMBER }}
     steps:
     - name: Get week number
       run:
-        echo "WEEK_NUMBER=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
+        echo "PR_NUMBER=$(date -u "+%V")" >> $GITHUB_OUTPUT
 
   test:
     needs: [linting, manifest, get-week-number]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     env:
-      WEEK_NUMBER: ${{ needs.get-week-number.outputs.week-number }}
+      WEEK_NUMBER: ${{ needs.get-week-number.outputs.pr-number }}
     strategy:
       matrix:
         # Run all supported Python versions on linux
@@ -60,9 +60,9 @@ jobs:
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
           enableCrossOsArchive: 'true'
-          key: brainglobe-$WEEK_NUMBER
+          key: brainglobe-{{ $WEEK_NUMBER }}
           restore-keys: |
-              brainglobe-$WEEK_NUMBER
+              brainglobe-{{ $WEEK_NUMBER }}
               brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,7 +37,7 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     env:
-      WEEK_NUMBER: ${{ needs.get-week-number.outputs.WEEK_NUMBER }}
+      WEEK_NUMBER: ${{ needs.get-week-number.outputs.week-number }}
     strategy:
       matrix:
         # Run all supported Python versions on linux

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -57,10 +57,10 @@ jobs:
           path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
-          enableCrossOsArchive: 'true'
-          key: brainglobe-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
+          key: brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
           restore-keys: |
-              brainglobe-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
+              brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
+              brainglobe-${{ runner.os }}-
               brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,8 +30,7 @@ jobs:
     steps:
     - name: Get week number
       id: get-week-number
-      run:
-        echo "WEEK_NUMBER=$(date -u "+%V")" >> "$GITHUB_OUTPUT"
+      run: echo "WEEK_NUMBER=$(date -u '+%V')" >> "$GITHUB_OUTPUT"
 
   test:
     needs: [linting, manifest, get-week-number]
@@ -59,9 +58,9 @@ jobs:
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
           enableCrossOsArchive: 'true'
-          key: brainglobe-${{ steps.get-week-number.outputs.WEEK_NUMBER }}
+          key: brainglobe-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
           restore-keys: |
-              brainglobe-${{ steps.get-week-number.outputs.WEEK_NUMBER }}
+              brainglobe-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
               brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,7 +33,7 @@ jobs:
         echo "week_number=$(/bin/date -u "+%V")" >> $GITHUB_OUTPUT
 
   test:
-    needs: [linting, manifest]
+    needs: [linting, manifest, get-week-number]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -302,10 +302,20 @@ def conf_from_url(url) -> configparser.ConfigParser:
     conf object
 
     """
-    text = requests.get(url).text
+    cache_path: Path = config.get_brainglobe_dir() / "last_versions.conf"
+
+    result = requests.get(url)
+    if result.status_code != 200:
+        print(
+            f"Could not fetch the latest atlas versions: {result.status_code}"
+        )
+        print(f"Using the last cached version from {cache_path}")
+
+        return conf_from_file(cache_path)
+
+    text = result.text
     config_obj = configparser.ConfigParser()
     config_obj.read_string(text)
-    cache_path: Path = config.get_brainglobe_dir() / "last_versions.conf"
 
     try:
         if not cache_path.parent.exists():

--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 from pathlib import Path
+from time import sleep
 from typing import Callable, Optional
 
 import requests
@@ -305,6 +306,15 @@ def conf_from_url(url) -> configparser.ConfigParser:
     cache_path: Path = config.get_brainglobe_dir() / "last_versions.conf"
 
     result = requests.get(url)
+    max_tries = 5
+    sleep_time = 0.25
+
+    while max_tries > 0 and result.status_code != 200:
+        result = requests.get(url)
+        max_tries -= 1
+        sleep(sleep_time)
+        sleep_time *= 2
+
     if result.status_code != 200:
         print(
             f"Could not fetch the latest atlas versions: {result.status_code}"


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Fetching from GIN can fail even if connected to the internet. This causes sporadic failures when trying to fetch the `last_versions.conf` file.

**What does this PR do?**
Adds retries to fetching the `last_versions.conf` file, if more than 5 retries it will try to use the locally cached file.

This PR also forces the cache to be refreshed at least once weekly, the old cache should be fetched and over written with a new cache tagged with `brainglobe-WEEK_NUMBER`. 

## References


Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
Tested locally, and via CI. It seems to decrease the frequency of sporadic errors.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
