### PR TITLE
Hemisphere improvements to axolotl atlas

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/axolotl_atlas.py
@@ -118,22 +118,32 @@ def create_atlas(working_dir, resolution):
                 row["id"] = row.pop("label_id")
                 row["acronym"] = row.pop("Abbreviation/reference")
                 hemisphere = row.pop("hemisphere")
-                row["acronym"] += f" ({hemisphere[0]})"
                 row["name"] = row.pop("label_name")
                 row["rgb_triplet"] = [255, 0, 0]
                 row.pop("voxels")
                 row.pop("volume")
 
-                if hemisphere[0] == "R":
+                if hemisphere[0] == "L":
+                    # mark as left hemisphere and add to hierarchy
                     hemispheres_stack[annotation_image == int(row["id"])] = 1
-                elif hemisphere[0] == "L":
+                    hierarchy.append(row)
+                elif hemisphere[0] == "R":
+                    # mark as right hemisphere
+                    # update annotation image to have equivalent left id
                     hemispheres_stack[annotation_image == int(row["id"])] = 2
+                    id_in_left_hemi = [
+                        int(region["id"])
+                        for region in hierarchy
+                        if region["acronym"] == row["acronym"]
+                    ][0]
+                    annotation_image[annotation_image == int(row["id"])] = (
+                        id_in_left_hemi
+                    )
                 else:
                     raise ValueError(
                         f"Unexpected hemisphere {hemisphere} "
                         f"for region {row['acronym']}"
                     )
-            hierarchy.append(row)
 
     # clean out different columns
     for element in hierarchy:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The UNAM axolotl atlas is asymmetric and has duplicate region acronyms (because the same region exists in each hemisphere)

**What does this PR do?**
- Computes and adds the (asymmetric) hemisphere stack for the axolotl atlas
- distinguishes duplicate region acronyms by labelling them L or R

## References

First tickbox of #359 
Closes #437 

## How has this PR been tested?

Visual inspection and validation script on local axolotl atlas.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

