### PR TITLE
Add additional atlas validation functions.

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -247,6 +247,8 @@ def validate_atlas_name(atlas: BrainGlobeAtlas):
 
 
 def get_all_validation_functions():
+    """Returns all individual validation functions as a list.
+    All functions should expect 1 argument, a BrainGlobeAtlas."""
     return [
         validate_atlas_files,
         validate_mesh_matches_image_extents,

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -232,7 +232,7 @@ def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
     label_5_right_of_centre = central_leftright_axis_annotations[centre[2] - 5]
     assert (
         label_5_left_of_centre == label_5_right_of_centre
-    ), "Annotation labels are asymmetric"
+    ), "Annotation labels are asymmetric."
     return True
 
 
@@ -242,7 +242,7 @@ def validate_atlas_name(atlas: BrainGlobeAtlas):
     """
     assert (
         atlas.atlas_name == atlas.atlas_name.lower()
-    ), "Atlas name cannot contain capitals."
+    ), f"Atlas name {atlas.atlas_name} cannot contain capitals."
     return True
 
 

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -173,6 +173,7 @@ def catch_missing_mesh_files(atlas: BrainGlobeAtlas):
             f"Structures with IDs {in_bg_not_mesh} are in the atlas, "
             "but don't have a corresponding mesh file."
         )
+    return True
 
 
 def catch_missing_structures(atlas: BrainGlobeAtlas):
@@ -205,6 +206,7 @@ def catch_missing_structures(atlas: BrainGlobeAtlas):
             f"Structures with IDs {in_mesh_not_bg} have a mesh file, "
             "but are not accessible through the atlas."
         )
+    return True
 
 
 def validate_reference_image_pixels(atlas: BrainGlobeAtlas):

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -236,6 +236,16 @@ def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
     return True
 
 
+def validate_atlas_name(atlas: BrainGlobeAtlas):
+    """
+    Ensures atlas names are all lowercase
+    """
+    assert (
+        atlas.atlas_name == atlas.atlas_name.lower()
+    ), "Atlas name cannot contain capitals."
+    return True
+
+
 def get_all_validation_functions():
     return [
         validate_atlas_files,
@@ -246,6 +256,7 @@ def get_all_validation_functions():
         catch_missing_structures,
         validate_reference_image_pixels,
         validate_annotation_symmetry,
+        validate_atlas_name,
     ]
 
 

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -215,7 +215,7 @@ def validate_reference_image_pixels(atlas: BrainGlobeAtlas):
     (MRI) data to wrapup function.
     """
     assert not np.all(
-        atlas.reference < 10
+        atlas.reference < 128
     ), f"Reference image is likely wrongly rescaled to {REFERENCE_DTYPE}"
     return True
 

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -9,6 +9,7 @@ from brainglobe_atlasapi.atlas_generation.validate_atlases import (
     _assert_close,
     catch_missing_mesh_files,
     catch_missing_structures,
+    get_all_validation_functions,
     validate_additional_references,
     validate_atlas_files,
     validate_image_dimensions,
@@ -20,9 +21,9 @@ from brainglobe_atlasapi.core import AdditionalRefDict
 
 @pytest.fixture
 def atlas():
-    """A fixture providing a low-res Allen Mouse atlas for testing.
+    """A fixture providing a small atlas for testing.
     Tests assume this atlas is valid"""
-    return BrainGlobeAtlas("allen_mouse_100um")
+    return BrainGlobeAtlas("kim_dev_mouse_e11-5_mri-adc_31.5um")
 
 
 @pytest.fixture
@@ -120,8 +121,16 @@ def atlas_with_reference_matching_additional_reference():
     os.remove(additional_reference_name)
 
 
-def test_validate_mesh_matches_image_extents(atlas):
-    assert validate_mesh_matches_image_extents(atlas)
+def test_valid_atlas_passes_all_validations(atlas):
+    """
+    Check all our validation functions return True
+    for a valid atlas
+    """
+    validation_functions = get_all_validation_functions()
+    for validation_function in validation_functions:
+        assert validation_function(
+            atlas
+        ), f"Function {validation_function.__name__} fails on valid atlas."
 
 
 def test_validate_mesh_matches_image_extents_negative(mocker, atlas):
@@ -135,10 +144,6 @@ def test_validate_mesh_matches_image_extents_negative(mocker, atlas):
         AssertionError, match="differ by more than 10 times pixel size"
     ):
         validate_mesh_matches_image_extents(atlas)
-
-
-def test_valid_atlas_files(atlas):
-    assert validate_atlas_files(atlas)
 
 
 def test_invalid_atlas_path(atlas_with_bad_reference_file):
@@ -157,24 +162,24 @@ def test_assert_close_negative():
         _assert_close(99.5, 30, 2)
 
 
-def test_catch_missing_mesh_files(atlas):
+def test_catch_missing_mesh_files():
     """
     Tests if catch_missing_mesh_files function raises an error,
     when there is at least one structure in the atlas that doesn't have
     a corresponding obj file.
 
     Expected behaviour:
-    True for "allen_mouse_10um" (structure 545 doesn't have an obj file):
+    True for "allen_mouse_100um" (structure 545 doesn't have an obj file):
     fails the validation function,
     raises an error --> no output from this test function
     """
-
+    atlas_with_missing_mesh_file = BrainGlobeAtlas("allen_mouse_100um")
     with pytest.raises(
         AssertionError,
         match=r"Structures with IDs \[.*?\] are in the atlas, "
         "but don't have a corresponding mesh file.",
     ):
-        catch_missing_mesh_files(atlas)
+        catch_missing_mesh_files(atlas_with_missing_mesh_file)
 
 
 def test_catch_missing_structures(atlas_with_missing_structure):
@@ -196,11 +201,6 @@ def test_catch_missing_structures(atlas_with_missing_structure):
         catch_missing_structures(atlas_with_missing_structure)
 
 
-def test_atlas_image_dimensions_match(atlas):
-    """Check the atlas passes the annotation-reference dimension validation"""
-    assert validate_image_dimensions(atlas)
-
-
 def test_atlas_image_dimensions_match_negative(
     atlas_with_bad_reference_tiff_content,
 ):
@@ -211,14 +211,6 @@ def test_atlas_image_dimensions_match_negative(
         match=r"Annotation and reference image have different dimensions.*",
     ):
         validate_image_dimensions(atlas_with_bad_reference_tiff_content)
-
-
-def test_atlas_additional_reference_different(
-    atlas_with_valid_additional_reference,
-):
-    """Checks that an atlas with a reasonably sized additional reference
-    passes its validation."""
-    validate_additional_references(atlas_with_valid_additional_reference)
 
 
 def test_atlas_additional_reference_same(

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -20,7 +20,7 @@ from brainglobe_atlasapi.core import AdditionalRefDict
 
 
 @pytest.fixture
-def atlas():
+def valid_atlas():
     """A fixture providing a small atlas for testing.
     Tests assume this atlas is valid"""
     return BrainGlobeAtlas("kim_dev_mouse_e11-5_mri-adc_31.5um")
@@ -121,7 +121,7 @@ def atlas_with_reference_matching_additional_reference():
     os.remove(additional_reference_name)
 
 
-def test_valid_atlas_passes_all_validations(atlas):
+def test_valid_atlas_passes_all_validations(valid_atlas):
     """
     Check all our validation functions return True
     for a valid atlas
@@ -129,12 +129,12 @@ def test_valid_atlas_passes_all_validations(atlas):
     validation_functions = get_all_validation_functions()
     for validation_function in validation_functions:
         assert validation_function(
-            atlas
+            valid_atlas
         ), f"Function {validation_function.__name__} fails on valid atlas."
 
 
-def test_validate_mesh_matches_image_extents_negative(mocker, atlas):
-    flipped_annotation_image = np.transpose(atlas.annotation)
+def test_validate_mesh_matches_image_extents_negative(mocker, valid_atlas):
+    flipped_annotation_image = np.transpose(valid_atlas.annotation)
     mocker.patch(
         "brainglobe_atlasapi.BrainGlobeAtlas.annotation",
         new_callable=mocker.PropertyMock,
@@ -143,7 +143,7 @@ def test_validate_mesh_matches_image_extents_negative(mocker, atlas):
     with pytest.raises(
         AssertionError, match="differ by more than 10 times pixel size"
     ):
-        validate_mesh_matches_image_extents(atlas)
+        validate_mesh_matches_image_extents(valid_atlas)
 
 
 def test_invalid_atlas_path(atlas_with_bad_reference_file):


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**What does this PR do?**
Improves our validation functions based on experiences with
* atlas names needing to be lowercase https://github.com/brainglobe/brainglobe-atlasapi/pull/446
* wrapup rescaling float64 data too naively https://github.com/brainglobe/brainglobe-atlasapi/pull/441#issuecomment-2589666369
* some atlases having differing annotations for the same region in the opposite hemisphere (e.g. #451 and #438 )

so the above issues will be flagged automatically during packaging in the future, when we merge #445 

Also, refactors our validation tests for simplicity, and makes sure we are actually testing validation functions on a valid atlas (for the tests we expect them to pass).