### PR TITLE
fix hemispheres being cut slightly off-centred

### DIFF
--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -136,7 +136,7 @@ class Atlas:
                 # Fill out with 2s the right hemisphere:
                 slices = [slice(None) for _ in range(3)]
                 slices[front_ax_idx] = slice(
-                    stack.shape[front_ax_idx] // 2 + 1, None
+                    round(stack.shape[front_ax_idx] / 2), None
                 )
                 stack[tuple(slices)] = 1
 

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -56,14 +56,14 @@ def test_additional_ref_dict(temp_path):
 @pytest.mark.parametrize(
     "stack_name, val",
     [
-        ("reference", [[[146, 155], [153, 157]], [[148, 150], [153, 153]]]),
-        ("annotation", [[[59, 362], [59, 362]], [[59, 362], [59, 362]]]),
+        ("reference", [[[155, 146], [157, 153]], [[151, 148], [154, 153]]]),
+        ("annotation", [[[59, 59], [59, 59]], [[59, 59], [59, 59]]]),
         ("hemispheres", [[[2, 1], [2, 1]], [[2, 1], [2, 1]]]),
     ],
 )
 def test_stacks(atlas, stack_name, val):
     loaded_stack = getattr(atlas, stack_name)
-    assert np.allclose(loaded_stack[65:67, 39:41, 57:59], val)
+    assert np.allclose(loaded_stack[65:67, 39:41, 56:58], val)
 
 
 def test_structures(atlas):
@@ -92,13 +92,13 @@ def test_data_from_coords(atlas, coords):
         )
         == "root"
     )
-    assert atlas.hemisphere_from_coords(coords) == atlas.right_hemisphere_value
-    assert atlas.hemisphere_from_coords(coords, as_string=True) == "right"
+    assert atlas.hemisphere_from_coords(coords) == atlas.left_hemisphere_value
+    assert atlas.hemisphere_from_coords(coords, as_string=True) == "left"
     assert (
         atlas.hemisphere_from_coords(
             [c * r for c, r in zip(coords, res)], microns=True, as_string=True
         )
-        == "right"
+        == "left"
     )
 
 


### PR DESCRIPTION
This fixes a small problem with _~symmetric_ atlases with an even-sized frontal axis to be cut slightly off-centred.

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This produces

**What does this PR do?**

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
```python
import numpy as np
from brainglobe_atlasapi import BrainGlobeAtlas

atlas = BrainGlobeAtlas(atlas_name="allen_mouse_10um")
round(atlas.metadata["shape"][2] / 2)
all(atlas.hemispheres[0,0,571:] == 1)
all(atlas.hemispheres[0,0,:571] == 2)
```

last two commands should be `True` only with 570, not with 571 as the splitting axis depth.

Additionally, this is also shown in ABBA, as atlas annotations imported with the auxilium of BrainGlobe are offcentred:

![image](https://github.com/user-attachments/assets/73e17246-877a-4a32-8f1e-d278bbb57a44)

From the image, you can notice that BrainGlobe's (yellow) and ABBA's ASR annotations fully overlap, however BrainGlobe splits the hemispheres slightly on the right.

P.S. the left annotations are from ABBA's RSA atlas. For some reason the transformation shifted it one unit (µm). Dunno the reason, but that's not the point.

this is the result with this PR:

![image](https://github.com/user-attachments/assets/f109d087-09d2-4afe-a88a-3447995d3faf)

## Is this a breaking change?

Not that I am aware of.

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
