### PR TITLE
add support for custom offline atlases

### DIFF
--- a/brainglobe_atlasapi/list_atlases.py
+++ b/brainglobe_atlasapi/list_atlases.py
@@ -59,18 +59,22 @@ def get_local_atlas_version(atlas_name):
 def get_all_atlases_lastversions():
     """Read from URL or local cache all available last versions"""
     cache_path = config.get_brainglobe_dir() / "last_versions.conf"
+    custom_path = config.get_brainglobe_dir() / "custom.conf"
 
     if utils.check_internet_connection(
         raise_error=False
     ) and utils.check_gin_status(raise_error=False):
-        available_atlases = utils.conf_from_url(
+        official_atlases = utils.conf_from_url(
             descriptors.remote_url_base.format("last_versions.conf")
         )
     else:
         print("Cannot fetch latest atlas versions from the server.")
-        available_atlases = utils.conf_from_file(cache_path)
-
-    return dict(available_atlases["atlases"])
+        official_atlases = utils.conf_from_file(cache_path)
+    try:
+        custom_atlases = utils.conf_from_file(custom_path)
+    except FileNotFoundError:
+        return dict(official_atlases["atlases"])
+    return dict(official_atlases["atlases"]) | dict(custom_atlases["atlases"])
 
 
 def get_atlases_lastversions():

--- a/brainglobe_atlasapi/list_atlases.py
+++ b/brainglobe_atlasapi/list_atlases.py
@@ -74,7 +74,7 @@ def get_all_atlases_lastversions():
         custom_atlases = utils.conf_from_file(custom_path)
     except FileNotFoundError:
         return dict(official_atlases["atlases"])
-    return dict(official_atlases["atlases"]) | dict(custom_atlases["atlases"])
+    return {**official_atlases["atlases"], **custom_atlases["atlases"]}
 
 
 def get_atlases_lastversions():

--- a/brainglobe_atlasapi/list_atlases.py
+++ b/brainglobe_atlasapi/list_atlases.py
@@ -59,7 +59,7 @@ def get_local_atlas_version(atlas_name):
 def get_all_atlases_lastversions():
     """Read from URL or local cache all available last versions"""
     cache_path = config.get_brainglobe_dir() / "last_versions.conf"
-    custom_path = config.get_brainglobe_dir() / "custom.conf"
+    custom_path = config.get_brainglobe_dir() / "custom_atlases.conf"
 
     if utils.check_internet_connection(
         raise_error=False


### PR DESCRIPTION
With this small PR, i want to enable atlas developers to test their atlases using BrainGlobe's pipeline.
As of now, if the atlas is not official (i.e. present on the Gin repository), it updates the `last_versions.conf` file overriding any local changes that may have added a new custom local atlas.

This PR intends to read the atlases from both the cached file of `last_versions.conf` and `custom_atlases.conf` file.
`custom_atlases.conf` follows the same structure as `last_versions.conf`.

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

## References

discussed over [on Zulip](https://brainglobe.zulipchat.com/#narrow/channel/390955-general/topic/adult.20mouse.203D.20atlas.20with.20dorsal.2Fventral.20distinction/near/495003139).

## How has this PR been tested?

`python -c "import brainglobe_atlasapi as bg; print(bg.list_atlases.get_all_atlases_lastversions())"`

with `custom_atlases.conf` file both existing and not.

## Is this a breaking change?

no

## Does this PR require an update to the documentation?

Perhaps?

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
