### PR TITLE
Adds fixture to download atlases for test_validation.py

### DIFF
--- a/tests/atlasgen/conftest.py
+++ b/tests/atlasgen/conftest.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+from brainglobe_atlasapi import BrainGlobeAtlas
+
+
+@pytest.fixture(autouse=True)
+def setup_preexisting_local_atlases():
+    """Automatically setup all tests to have three downloaded atlases
+    in the test user data."""
+    preexisting_atlases = [
+        ("example_mouse_100um", "v1.2"),
+        ("allen_mouse_100um", "v1.2"),
+        ("kim_dev_mouse_e11-5_mri-adc_31.5um", "v1.3"),
+    ]
+    for atlas_name, version in preexisting_atlases:
+        if not Path.exists(
+            Path.home() / f".brainglobe/{atlas_name}_{version}"
+        ):
+            _ = BrainGlobeAtlas(atlas_name)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Tests were failing as `test_validation.py` tried to modify a directory that didn't exist. 

https://github.com/brainglobe/brainglobe-atlasapi/actions/runs/13244823116/job/36975288009?pr=497

This failure seems to be related to the CI cache miss.

**What does this PR do?**
Ensures atlases are downloaded prior to `test_validation.py` running.

## How has this PR been tested?
All tests pass locally and on CI.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
