### PR TITLE
Adds fixture to mock home for local testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,54 @@
+import os
 import shutil
 import tempfile
 from pathlib import Path
 
 import pytest
 
-from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas
+from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas, config
+
+
+@pytest.fixture(autouse=True)
+def mock_brainglobe_user_folders(monkeypatch):
+    """Ensures user config and data is mocked during all local testing.
+
+    User config and data need mocking to avoid interfering with user data.
+    Mocking is achieved by turning user data folders used in tests into
+    subfolders of a new ~/.brainglobe-tests folder instead of ~/.
+
+    It is not sufficient to mock the home path in the tests, as this
+    will leave later imports in other modules unaffected.
+
+    GH actions workflow will test with default user folders.
+    """
+    if not os.getenv("GITHUB_ACTIONS"):
+        home_path = Path.home()  # actual home path
+        mock_home_path = home_path / ".brainglobe-tests"
+        if not mock_home_path.exists():
+            mock_home_path.mkdir()
+
+        def mock_home():
+            return mock_home_path
+
+        monkeypatch.setattr(Path, "home", mock_home)
+
+        # also mock global variables of config.py
+        monkeypatch.setattr(
+            config, "DEFAULT_PATH", mock_home_path / ".brainglobe"
+        )
+        monkeypatch.setattr(
+            config, "CONFIG_DIR", mock_home_path / ".config" / "brainglobe"
+        )
+        monkeypatch.setattr(
+            config, "CONFIG_PATH", config.CONFIG_DIR / config.CONFIG_FILENAME
+        )
+        mock_default_dirs = {
+            "default_dirs": {
+                "brainglobe_dir": mock_home_path / ".brainglobe",
+                "interm_download_dir": mock_home_path / ".brainglobe",
+            }
+        }
+        monkeypatch.setattr(config, "TEMPLATE_CONF_DICT", mock_default_dirs)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Our current test suite ends up modifying the local `.brainglobe` directory. This may cause inconsistent behaviour during local testing as the state of the `.brainglobe` directory can't be guaranteed, further, running tests locally may alter the `.brainglobe` directory unintentionally.

**What does this PR do?**
Mocks the home directory when tests are run locally as seen https://github.com/brainglobe/brainrender-napari/blob/9b3253758ea9efc4c56bb79d060d0af8c058420f/tests/conftest.py#L11.

## References
Closes #302

## How has this PR been tested?
All tests pass locally and use the `~/.brainglobe-tests/.brainglobe` directory instead of the `.brainglobe` directory.

## Is this a breaking change?
No, running tests locally for the first time may take a bit longer. This can be avoided by moving the required atlases from `.brainglobe` to `.brainglobe-tests/.brainglobe`

## Does this PR require an update to the documentation?
No?

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
