### PR TITLE
Remove inspect_meshes_folder function

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_cord.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_cord.py
@@ -17,7 +17,6 @@ from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     Region,
     create_region_mesh,
-    inspect_meshes_folder,
 )
 from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
 from brainglobe_atlasapi.config import DEFAULT_WORKDIR
@@ -181,10 +180,6 @@ def create_meshes(download_dir_path, structures, annotated_volume, root_id):
         round((time.time() - start) / 60, 2),
         " minutes",
     )
-
-    if TEST:
-        # create visualization of the various meshes
-        inspect_meshes_folder(meshes_dir_path)
 
     return meshes_dir_path
 

--- a/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_human.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_scripts/allen_human.py
@@ -17,7 +17,6 @@ from brainglobe_atlasapi import utils
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     Region,
     create_region_mesh,
-    inspect_meshes_folder,
 )
 from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
 from brainglobe_atlasapi.config import DEFAULT_WORKDIR
@@ -33,7 +32,6 @@ ORIENTATION = "rpi"
 
 ### Settings
 PARALLEL = False  # disable parallel mesh extraction for easier debugging
-TEST = False
 
 
 def prune_tree(tree):
@@ -278,10 +276,6 @@ def create_atlas(working_dir):
         round((time.time() - start) / 60, 2),
         " minutes",
     )
-
-    if TEST:
-        # create visualization of the various meshes
-        inspect_meshes_folder(meshes_dir_path)
 
     # Create meshes dict
     meshes_dict = dict()

--- a/brainglobe_atlasapi/atlas_generation/mesh_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/mesh_utils.py
@@ -1,6 +1,6 @@
 try:
-    from vedo import Mesh, Volume, load, show, write
-    from vedo.applications import Browser, Slicer3DPlotter
+    from vedo import Mesh, Volume, write
+    from vedo.applications import Slicer3DPlotter
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
         "Mesh generation with these utils requires vedo\n"
@@ -278,34 +278,3 @@ def compare_mesh_and_volume(mesh, volume):
     vp = Slicer3DPlotter(volume, bg2="white", showHisto=False)
     vp.add(mesh.alpha(0.5))
     vp.show()
-
-
-def inspect_meshes_folder(folder):
-    """
-    Used to create an interactive vedo visualisation
-    to scroll through all .obj files saved in a folder
-
-    Parameters
-    ----------
-    folder: str or Path object
-        path to folder with .obj files
-    """
-
-    if isinstance(folder, str):
-        folder = Path(folder)
-
-    if not folder.exists():
-        raise FileNotFoundError("The folder passed doesnt exist")
-
-    mesh_files = folder.glob("*.obj")
-
-    Browser([load(str(mf)).c("w").lw(0.25).lc("k") for mf in mesh_files])
-    logger.debug("visualization ready")
-    show()
-
-
-if __name__ == "__main__":
-    folder = (
-        r"C:\Users\Federico\.brainglobe\temp\allen_human_500um_v0.1\meshes"
-    )
-    inspect_meshes_folder(folder)


### PR DESCRIPTION
This removes the inspect_meshes_folder function that was originally used to, well, inspect the meshes during atlas packaging. Now we have far better validation functions, this is not used anymore. 

Closes #311 