### PR TITLE
get correct major version from atlas name

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -53,10 +53,10 @@ def _rich_atlas_metadata(atlas_name, metadata):
     tb.add_row(
         "name:",
         Text.from_markup(
-            metadata["name"] + f' [{gray}](v{metadata["version"]})'
+            metadata["name"] + f" [{gray}](v{metadata['version']})"
         ),
     )
-    tb.add_row("species:", Text.from_markup(f'[i]{metadata["species"]}'))
+    tb.add_row("species:", Text.from_markup(f"[i]{metadata['species']}"))
     tb.add_row("citation:", Text.from_markup(f"{cit_name} [{gray}]{cit_link}"))
     tb.add_row("link:", Text.from_markup(metadata["atlas_link"]))
 
@@ -86,7 +86,7 @@ def atlas_repr_from_name(name):
 
     # For unspecified version:
     if version_str:
-        major_vers, minor_vers = version_str[2:].split(".")
+        major_vers, minor_vers = version_str[1:].split(".")
     else:
         major_vers, minor_vers = None, None
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
While adding a test for `utils.atlas_repr_from_name` (see [add test_atlas_repr_from_name](https://github.com/brainglobe/brainglobe-atlasapi/pull/518/commits/5b76e7f8e3e41b572c9241fcad96eb93dfe26ace)) I discovered what I think is a minor bug.

`utils.atlas_repr_from_name` generates a dictionary with the atlas description given the atlas name but doesn't fetch the correct `major version` (it's always an empty string).

For example, `axolotl_1um_v5.3` results in
```
            {
                "name": "axolotl",
                "major_vers": "",
                "minor_vers": "3",
                "resolution": "1",
            }
```
While I think it should be
```
            {
                "name": "axolotl",
                "major_vers": "5",
                "minor_vers": "3",
                "resolution": "1",
            }
```

**What does this PR do?**
Changes the indexing to fetch `major_vers`.

## References
#518

## How has this PR been tested?
Added `test_atlas_repr_from_name` to `test_utils.py` with `XFAIL` marker that can be removed after this PR is merged.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
