### PR TITLE
minor bug fix utils.retrieve_over_http

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -53,10 +53,10 @@ def _rich_atlas_metadata(atlas_name, metadata):
     tb.add_row(
         "name:",
         Text.from_markup(
-            metadata["name"] + f' [{gray}](v{metadata["version"]})'
+            metadata["name"] + f" [{gray}](v{metadata['version']})"
         ),
     )
-    tb.add_row("species:", Text.from_markup(f'[i]{metadata["species"]}'))
+    tb.add_row("species:", Text.from_markup(f"[i]{metadata['species']}"))
     tb.add_row("citation:", Text.from_markup(f"{cit_name} [{gray}]{cit_link}"))
     tb.add_row("link:", Text.from_markup(metadata["atlas_link"]))
 
@@ -225,7 +225,7 @@ def retrieve_over_http(
                         fn_update(completed, tot)
 
     except requests.exceptions.ConnectionError:
-        output_file_path.unlink()
+        output_file_path.unlink(missing_ok=True)
         raise requests.exceptions.ConnectionError(
             f"Could not download file from {url}"
         )


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
While adding a test for `utils.retrieve_over_http` (see [add test_atlas_repr_from_name](https://github.com/brainglobe/brainglobe-atlasapi/pull/518/commits/5b76e7f8e3e41b572c9241fcad96eb93dfe26ace)) I noticed that when there is a connection error and no file in the specified `output_file_path` exists, the block of code below errors at `output_file_path.unlink()`, throwing an `FileNotFoundError`, instead of raising the `ConnectionError `(which is I think what is desired in this case).
```
    except requests.exceptions.ConnectionError:
        output_file_path.unlink()
        raise requests.exceptions.ConnectionError(
            f"Could not download file from {url}"
        )
```      
**What does this PR do?**
sets `output_file_path.unlink(missing_ok=True)` so that the correct error message is shown in case of an `ConnectionError`.

## References
#518

## How has this PR been tested?
Added `test_retrieve_over_http_ConnectionError` to `test_utils.py` with `XFAIL` marker that can be removed after this PR is merged.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
