### PR TITLE
Increase atlas name validation stringency

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -249,18 +249,17 @@ def validate_atlas_name(atlas: BrainGlobeAtlas):
     allowed_chars = r"^[a-z0-9_.-]+$"
     res = name.split("_").pop()
 
-    assert (
-        name == name.lower()
-    ), f"Atlas name {atlas.atlas_name} cannot contain capitals."
+    assert name == name.lower(), f"Atlas name {name} cannot contain capitals."
 
     assert re.match(
         allowed_chars, name
     ), f"Atlas name {name} contains invalid characters."
 
     resolution_pattern = r"\d+(\.\d+)?(um|mm)$"
-    assert re.search(
-        resolution_pattern, res
-    ), "Atlas name must end with its resolution (e.g. 5um, 37.5um, 1mm)."
+    assert re.search(resolution_pattern, res), (
+        f"Atlas name {name} should end with a valid resolution "
+        "(e.g., 5um, 1.5mm)."
+    )
 
     return True
 

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from pathlib import Path
 
 import numpy as np
@@ -56,8 +57,7 @@ def _assert_close(mesh_coord, annotation_coord, pixel_size, diff_tolerance=10):
     assert abs(mesh_coord - annotation_coord) <= diff_tolerance * pixel_size, (
         f"Mesh coordinate {mesh_coord} and "
         f"annotation coordinate {annotation_coord}",
-        f"differ by more than {diff_tolerance} "
-        f"times pixel size {pixel_size}",
+        f"differ by more than {diff_tolerance} times pixel size {pixel_size}",
     )
     return True
 
@@ -240,12 +240,28 @@ def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
 
 
 def validate_atlas_name(atlas: BrainGlobeAtlas):
+    """Validate atlas name.
+    - Can contain: lowercase letters, digits, underscores, hyphens, periods
+    - Ends with resolution (e.g., 5um, 37.5um, 1mm)
+    - Resolution: number + um (micrometers) or mm (millimeters)
     """
-    Ensures atlas names are all lowercase
-    """
+    name = atlas.atlas_name
+    allowed_chars = r"^[a-z0-9_.-]+$"
+    res = name.split("_").pop()
+
     assert (
-        atlas.atlas_name == atlas.atlas_name.lower()
+        name == name.lower()
     ), f"Atlas name {atlas.atlas_name} cannot contain capitals."
+
+    assert re.match(
+        allowed_chars, name
+    ), f"Atlas name {name} contains invalid characters."
+
+    resolution_pattern = r"\d+(\.\d+)?(um|mm)$"
+    assert re.search(
+        resolution_pattern, res
+    ), "Atlas name must end with its resolution (e.g. 5um, 37.5um, 1mm)."
+
     return True
 
 

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -228,11 +228,7 @@ class BrainGlobeAtlas(core.Atlas):
     def __repr__(self):
         """Fancy print providing atlas information."""
         name_split = self.atlas_name.split("_")
-        res = (
-            f" (res. {name_split.pop()})"
-            if name_split[-1].endswith("um")
-            else ""
-        )
+        res = f" (res. {name_split.pop()})"
         pretty_name = f"{' '.join(name_split)} atlas{res}"
         return pretty_name
 

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -271,3 +271,39 @@ def test_upper_case_name_fails(atlas):
         match=r"cannot contain capitals.",
     ):
         validate_atlas_name(atlas)
+
+
+def test_invalid_characters_in_name_fails(atlas):
+    """Checks that an atlas with invalid characters in name fails"""
+    atlas.atlas_name = "invalid@name"
+    with pytest.raises(
+        AssertionError,
+        match=r"contains invalid characters.",
+    ):
+        validate_atlas_name(atlas)
+
+
+def test_missing_resolution_in_name_fails(atlas):
+    """Checks that an atlas name without resolution fails"""
+    atlas.atlas_name = "atlas_name_without_resolution"
+    with pytest.raises(
+        AssertionError,
+        match=r"must end with it's resolution",
+    ):
+        validate_atlas_name(atlas)
+
+
+def test_invalid_resolution_format_in_name_fails(atlas):
+    """Checks that an atlas name with invalid resolution format fails"""
+    atlas.atlas_name = "valid_name_with_invalid_resolution_100xum"
+    with pytest.raises(
+        AssertionError,
+        match=r"must end with it's resolution",
+    ):
+        validate_atlas_name(atlas)
+
+
+def test_valid_atlas_name_passes(atlas):
+    """Checks that a valid atlas name passes"""
+    atlas.atlas_name = "valid_name_100um"
+    assert validate_atlas_name(atlas)

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import numpy as np
 import pytest
@@ -263,47 +264,44 @@ def test_asymmetrical_annotation_fails(mocker, atlas):
         validate_annotation_symmetry(atlas)
 
 
-def test_upper_case_name_fails(atlas):
-    """Checks that an atlas with capital letters in name fails"""
-    atlas.atlas_name = atlas.atlas_name.upper()
-    with pytest.raises(
-        AssertionError,
-        match=r"cannot contain capitals.",
-    ):
-        validate_atlas_name(atlas)
-
-
-def test_invalid_characters_in_name_fails(atlas):
-    """Checks that an atlas with invalid characters in name fails"""
-    atlas.atlas_name = "invalid@name"
-    with pytest.raises(
-        AssertionError,
-        match=r"contains invalid characters.",
-    ):
-        validate_atlas_name(atlas)
-
-
-def test_missing_resolution_in_name_fails(atlas):
-    """Checks that an atlas name without resolution fails"""
-    atlas.atlas_name = "atlas_name_without_resolution"
-    with pytest.raises(
-        AssertionError,
-        match=r"must end with it's resolution",
-    ):
-        validate_atlas_name(atlas)
-
-
-def test_invalid_resolution_format_in_name_fails(atlas):
-    """Checks that an atlas name with invalid resolution format fails"""
-    atlas.atlas_name = "valid_name_with_invalid_resolution_100xum"
-    with pytest.raises(
-        AssertionError,
-        match=r"must end with it's resolution",
-    ):
-        validate_atlas_name(atlas)
-
-
-def test_valid_atlas_name_passes(atlas):
-    """Checks that a valid atlas name passes"""
-    atlas.atlas_name = "valid_name_100um"
-    assert validate_atlas_name(atlas)
+@pytest.mark.parametrize(
+    "atlas_name, should_pass, error_message",
+    [
+        pytest.param(
+            "CONTAINS_CAPITALS_1um",
+            False,
+            "cannot contain capitals.",
+            id="upper case",
+        ),
+        pytest.param(
+            "contains_inv@lid_character_1um",
+            False,
+            "contains invalid characters.",
+            id="invalid charachter (@)",
+        ),
+        pytest.param(
+            "10um_atlas_name_does_not_end_with_resolution",
+            False,
+            "should end with a valid resolution (e.g., 5um, 1.5mm).",
+            id="doesn't end with resolution",
+        ),
+        pytest.param(
+            "atlas_name_with_invalid_resolution_100m",
+            False,
+            "should end with a valid resolution (e.g., 5um, 1.5mm).",
+            id="invalid resolution (100m)",
+        ),
+        pytest.param("valid_name_100um", True, None, id="valid_name_100um"),
+        pytest.param("valid-name_1mm", True, None, id="valid-name_1mm"),
+    ],
+)
+def test_validate_atlas_name(atlas_name, should_pass, error_message):
+    """Checks various atlas name validation cases"""
+    atlas = object.__new__(BrainGlobeAtlas)
+    atlas.atlas_name = atlas_name
+    if should_pass:
+        assert validate_atlas_name(atlas)
+    else:
+        error_message = f"Atlas name {atlas_name} " + error_message
+        with pytest.raises(AssertionError, match=re.escape(error_message)):
+            validate_atlas_name(atlas)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To validate/enforce stricter naming convention. 

**What does this PR do?**
`validate_atlas_name` checks the following constraints.

Atlas name
- Can contain: lowercase letters, digits, underscores, hyphens, periods
- Ends with resolution (e.g., 5um, 37.5um, 1mm)
- Resolution: number + um (micrometers) or mm (millimeters)

## References
#524

## How has this PR been tested?
`test_validate_atlas_name` covers:

- **Upper Case Letters**: Names must not contain capital letters. Example: `"CONTAINS_CAPITALS_1um"` should fail.
- **Invalid Characters**: Names must only contain lowercase letters, digits, underscores, hyphens, and periods. Example: `"contains_inv@lid_character_1um"` should fail.
- **Resolution Format**: Names must end with a valid resolution (e.g., `5um`, `1.5mm`). Examples: `"10um_atlas_name_does_not_end_with_resolution"` and `"atlas_name_with_invalid_resolution_100m"` should fail.
- **Valid Names**: Names that meet all criteria should pass. Examples: `"valid_name_100um"` and `"valid-name_1mm"` should pass.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
