### PR TITLE
Increase update_atlases test coverage

### DIFF
--- a/brainglobe_atlasapi/update_atlases.py
+++ b/brainglobe_atlasapi/update_atlases.py
@@ -77,7 +77,10 @@ def install_atlas(atlas_name, fn_update=None):
 
     # Check input:
     if not isinstance(atlas_name, str):
-        raise ValueError(f"atlas name should be a string, not {atlas_name}")
+        raise TypeError(
+            f"Atlas name should be a string, not a "
+            f"{type(atlas_name).__name__}."
+        )
 
     # Check if already downloaded:
     available_atlases = get_downloaded_atlases()

--- a/tests/atlasapi/test_update_atlas.py
+++ b/tests/atlasapi/test_update_atlas.py
@@ -13,3 +13,14 @@ def test_update_wrong_name():
     with pytest.raises(ValueError) as error:
         update_atlases.update_atlas("allen_madasadsdouse_25um")
     assert "is not a valid atlas name!" in str(error)
+
+
+def test_update_atlas_value_error(mocker):
+    """Test error on old atlas deletion failure."""
+    mocker.patch("shutil.rmtree")
+    expected_error = "Something went wrong while trying to delete the old"
+    " version of the atlas, aborting."
+    with pytest.raises(ValueError, match=expected_error):
+        update_atlases.update_atlas(
+            atlas_name="example_mouse_100um", force=True
+        )

--- a/tests/atlasapi/test_update_atlas.py
+++ b/tests/atlasapi/test_update_atlas.py
@@ -24,3 +24,34 @@ def test_update_atlas_value_error(mocker):
         update_atlases.update_atlas(
             atlas_name="example_mouse_100um", force=True
         )
+
+
+@pytest.mark.parametrize(
+    "input, input_type",
+    [
+        pytest.param(0, "int"),
+        pytest.param(0.1, "float"),
+        pytest.param([], "list"),
+        pytest.param(None, "NoneType"),
+    ],
+)
+def test_install_atlas(input, input_type):
+    """Test correct raising of TypeError"""
+    expected_error = f"Atlas name should be a string, not a {input_type}"
+    with pytest.raises(TypeError, match=expected_error):
+        update_atlases.install_atlas(atlas_name=input)
+
+
+def test_install_atlas_istantiate_download(mocker):
+    """Test download instantiation when no local atlases are available."""
+    name = "example_mouse_100um"
+    with mocker.patch(
+        "brainglobe_atlasapi.update_atlases.get_downloaded_atlases",
+        return_value=[],
+    ):
+        mock_BrainGlobeAtlas = mocker.patch(
+            "brainglobe_atlasapi.update_atlases.BrainGlobeAtlas"
+        )
+        update_atlases.install_atlas(atlas_name=name)
+
+    mock_BrainGlobeAtlas.assert_called_once_with(name, fn_update=None)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Make code in `brainglobe-atlasapi` more robust by increasing test coverage.

**What does this PR do?**
- Increase test coverage `update_atlases.py`
- Replaces `install_atlas` `ValueError `with a `TypeError `if atlas_name is not a string specifying the expected type.

## References
#518 

## How has this PR been tested?

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
