### PR TITLE
[ENH] Fix internet connection check for global accessibility

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -122,19 +122,33 @@ def check_internet_connection(
     raise_error : bool
         if false, warning but no error.
     """
+    urls_to_try = [url]
 
-    try:
-        _ = requests.get(url, timeout=timeout)
+    if url == "http://www.google.com/":
+        # fallback URLs that are globally accessible
+        fallback_urls = [
+            "https://pypi.org/",
+            "https://www.bing.com/",
+            "https://gitee.com/",
+            "http://perdu.com/",
+        ]
 
-        return True
-    except requests.ConnectionError as e:
-        if not raise_error:
-            print("No internet connection available.")
-        else:
-            raise ConnectionError(
-                "No internet connection, try again when you are "
-                "connected to the internet."
-            ) from e
+        urls_to_try.extend([u for u in fallback_urls if u != url])
+
+    for current_url in urls_to_try:
+        try:
+            _ = requests.get(current_url, timeout=timeout)
+            return True
+        except requests.ConnectionError:
+            continue
+
+    if not raise_error:
+        print("No internet connection available.")
+    else:
+        raise ConnectionError(
+            "No internet connection, try again when you are "
+            "connected to the internet."
+        )
 
     return False
 


### PR DESCRIPTION
## Description  

**What is this PR**  
- [x] Bug fix  
- [ ] Addition of a new feature  
- [ ] Other  

**Why is this PR needed?**  
The internet check relied on Google, which is inaccessible in some regions. This PR adds fallback URLs for global accessibility.  

**What does this PR do?**  
Adds alternative URLs (`pypi.org`, `bing.com`, `gitee.com`, `perdu.com`) to ensure connectivity checks work everywhere.  

## References  

Fixes #522  

## How has this PR been tested?  
- Tested locally in environments with and without Google access.  
- Verified fallback URLs work as intended.  

## Is this a breaking change?  
No, it maintains backward compatibility.  

## Does this PR require an update to the documentation?  
No, functionality remains unchanged for users.  

## Checklist:  
- [x] The code has been tested locally  
- [ ] Tests have been added  
- [ ] Documentation updated if needed  
- [x] Code formatted with [[pre-commit](https://pre-commit.com/)](https://pre-commit.com/)  