### PR TITLE
minor bug fix atlas_gen/mesh_utils

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/mesh_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/mesh_utils.py
@@ -1,3 +1,5 @@
+from scipy.ndimage import binary_closing, binary_fill_holes
+
 try:
     from vedo import Mesh, Volume, write
     from vedo.applications import Slicer3DPlotter
@@ -18,7 +20,6 @@ except ModuleNotFoundError:
 from pathlib import Path
 
 import numpy as np
-import scipy
 from loguru import logger
 
 from brainglobe_atlasapi.atlas_generation.volume_utils import (
@@ -30,6 +31,7 @@ from brainglobe_atlasapi.atlas_generation.volume_utils import (
 # ----------------- #
 
 
+# TODO: is this function being used?
 def region_mask_from_annotation(
     structure_id,
     annotation,
@@ -121,7 +123,7 @@ def extract_mesh_from_mask(
             )
 
     # Check volume argument
-    if np.min(volume) > 0 or np.max(volume) < 1:
+    if not np.isin(volume, [0, 1]).all():
         raise ValueError(
             "Argument volume should be a binary mask with only "
             "0s and 1s when passing a np.ndarray"
@@ -129,10 +131,8 @@ def extract_mesh_from_mask(
 
     # Apply morphological transformations
     if closing_n_iters is not None:
-        volume = scipy.ndimage.morphology.binary_fill_holes(volume).astype(int)
-        volume = scipy.ndimage.morphology.binary_closing(
-            volume, iterations=closing_n_iters
-        ).astype(int)
+        volume = binary_fill_holes(volume).astype(int)
+        volume = binary_closing(volume, iterations=closing_n_iters).astype(int)
 
     if not use_marching_cubes:
         # Use faster algorithm

--- a/brainglobe_atlasapi/atlas_generation/mesh_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/mesh_utils.py
@@ -31,7 +31,6 @@ from brainglobe_atlasapi.atlas_generation.volume_utils import (
 # ----------------- #
 
 
-# TODO: is this function being used?
 def region_mask_from_annotation(
     structure_id,
     annotation,


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
When I started with implemeneting tests for `atlas_gen/mesh_utils.py` I encountered a minor bug and a `DeprecationWarning`.
- `extract_mesh_from_mask` does not handle binary masks with only 0s or only 1s
- `extract_mesh_from_mask` `DeprecationWarning: Please import `binary_fill_holes` from the `scipy.ndimage` namespace; the `scipy.ndimage.morphology` namespace is deprecated and will be removed in SciPy 2.0.0.`

**What does this PR do?**
- modify`extract_mesh_from_mask` to accept masks with only 0s or only 1s.
- import `binary_closing`, `binary_fill_holes` from `scipy.ndimage` to avoid Deprecation.

## References
#541  points 6 and 7

## How has this PR been tested?
Tests will be added in seperate PR. Codecov reports can be ignored for this PR.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
