### PR TITLE
Code coverage for brainglobe_atlasapi/core.py

### DIFF
--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -78,7 +78,7 @@ class BrainGlobeAtlas(core.Atlas):
 
             # If the default folder does not exist yet, make it:
             dir_path = Path(dir)
-            dir_path.mkdir(exist_ok=True)
+            dir_path.mkdir(parents=True, exist_ok=True)
             setattr(self, dirname, dir_path)
 
         # Look for this atlas in local brainglobe folder:

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -231,11 +231,21 @@ def test_get_structure_mask(atlas):
     ), "Values in grey_structure_mask should be either 0 or 7"
 
 
-# TODO: Add a docstring plus consider making this test more robust to handle
-# potential changes in the order of `read_json` calls or additional
-# `read_json` calls in the `__init__` method.
-def test_key_error_handling_for_additional_refer(atlas):
-    """"""
+def test_key_error_for_additional_references(atlas):
+    """
+    Test that a warning is issued when the 'additional_references' key
+    is missing from the atlas metadata.
+
+    Parameters
+    ----------
+    atlas : Atlas
+        An instance of the Atlas class used for testing.
+
+    Raises
+    ------
+    AssertionError
+        If the expected warning is not triggered.
+    """
     atlas.metadata.pop("additional_references")
     mock_metadata = atlas.metadata
     structures_list = atlas.structures_list

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -1,13 +1,14 @@
 import contextlib
 from io import StringIO
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pytest
 import tifffile
 
-from brainglobe_atlasapi.core import AdditionalRefDict, Atlas
+from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas
+from brainglobe_atlasapi.core import AdditionalRefDict
 
 
 def test_initialization(atlas):
@@ -231,41 +232,20 @@ def test_get_structure_mask(atlas):
     ), "Values in grey_structure_mask should be either 0 or 7"
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_atlas():
-    """Fixture to create a mocked Atlas object."""
-    with (
-        patch("brainglobe_atlasapi.utils.read_json") as mock_read_json,
-        patch("builtins.open", mock_open(read_data="{}")),
-        patch("pathlib.Path.exists", return_value=True),
-    ):
-        mock_read_json.side_effect = [
-            {"some_metadata": "value"},
-            [
-                {
-                    "id": 1,
-                    "acronym": "root",
-                    "name": "Root Structure",
-                    "parent": None,
-                },
-                {
-                    "id": 2,
-                    "acronym": "subregion",
-                    "name": "Subregion",
-                    "parent": 1,
-                },
-            ],
-        ]
-
-        atlas = Atlas("mock_path")
-        yield atlas
+    """Fixture to create an Atlas instance with mock data."""
+    atlas = BrainGlobeAtlas("example_mouse_100um")
+    atlas.metadata = {"some_metadata": "value"}
+    return atlas
 
 
 def test_key_error_handling_for_additional_references(mock_atlas):
-    """Test that a warning is issued when 'additional_references' is missing in metadata."""  # noqa: E501
+    """Test that a warning is issued when
+    'additional_references' is missing in metadata.
+    """
     with patch("warnings.warn") as mock_warn:
-        mock_atlas.metadata = {"some_metadata": "value"}
-        mock_atlas.__init__("mock_path")
+        mock_atlas.__init__("example_mouse_100um")
         mock_warn.assert_called_once_with(
-            "This atlas seems to be outdated as no additional_references list is found in metadata!"  # noqa: E501
+            "This atlas seems to be outdated as no additional_references list is found in metadata!"  # noqa E501
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,9 +58,7 @@ def atlas():
 
 @pytest.fixture()
 def asymmetric_atlas():
-    atlas = BrainGlobeAtlas("unam_axolotl_40um")
-    atlas.root_dir = Path("/tmp")
-    return atlas
+    return BrainGlobeAtlas("unam_axolotl_40um")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,13 @@ def atlas():
 
 
 @pytest.fixture()
+def asymmetric_atlas():
+    atlas = BrainGlobeAtlas("unam_axolotl_40um")
+    atlas.root_dir = Path("/tmp")
+    return atlas
+
+
+@pytest.fixture()
 def temp_path():
     path = Path(tempfile.mkdtemp())
     yield path


### PR DESCRIPTION
## Addressing #514 for brainglobe_atlasapi/core.py

**What is this PR**

- [x] Other: addressing #514 for brainglobe_atlasapi/core.py


**Why is this PR needed?**

**What does this PR do?**
Adds tests covering last uncovered lines in ` brainglobe_atlasapi/core.py`

## References
#514 

## How has this PR been tested?

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:
- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
