### PR TITLE
fix minor bugs in atlasgen/structures

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/structures.py
+++ b/brainglobe_atlasapi/atlas_generation/structures.py
@@ -19,9 +19,9 @@ def check_struct_consistency(structures):
     for struct in structures:
         try:
             assert struct.keys() == STEMPLATE.keys()
-            assert [
+            assert all(
                 isinstance(v, type(STEMPLATE[k])) for k, v in struct.items()
-            ]
+            )
         except AssertionError:
             raise AssertionError(
                 f"Inconsistencies found for structure {struct}"
@@ -55,15 +55,18 @@ def get_structure_children(structures, region, use_tree=False):
         sub_region_ids = []
         for subregion in structures:
             if region["id"] in subregion["structure_id_path"]:
-                sub_region_ids.append(subregion["id"])
+                if subregion["id"] is not region["id"]:
+                    sub_region_ids.append(subregion["id"])
     else:
         tree = get_structures_tree(structures)
         sub_region_ids = [
-            n.identifier for k, n in tree.subtree(region["id"]).nodes.items()
+            n.identifier
+            for k, n in tree.subtree(region["id"]).nodes.items()
+            if n.identifier is not region["id"]
         ]
 
     if sub_region_ids == []:
-        print(f'{region["acronym"]} doesnt seem to contain any other regions')
+        print(f"{region['acronym']} doesnt seem to contain any other regions")
         return None
     else:
         return sub_region_ids
@@ -87,7 +90,7 @@ def get_structure_terminal_nodes(structures, region):
     ]
 
     if not sub_region_ids:
-        print(f'{region["acronym"]} doesnt seem to contain any other regions')
+        print(f"{region['acronym']} doesnt seem to contain any other regions")
         return None
     else:
         return sub_region_ids


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
When I was writing tests (#543) covering atlasgen/structures, I noticed a few small bugs.
- `get_structure_children`: parent region is incorrectly included in `sub_region_ids` when there's no "children" (similar to bug fixed in #544), causing unreachable code.
- `check_struct_consistency`: `AssertionError` is only raised when _all_ value types mismatch the template value types.

**What does this PR do?**
Fixes both bugs 🐛 
- `get_structure_children`: parent region is never included in `sub_region_ids`.
- `check_struct_consistency`: `AssertionError` is raised when _any_ value type mismatches the template value types. 

## References

## How has this PR been tested?
#543 (remove xfail markers after merging this PR), codecov fails can be ignored. 

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
