### PR TITLE
remove xfail marker from atlasgen/test_structures

### DIFF
--- a/tests/atlasgen/test_structures.py
+++ b/tests/atlasgen/test_structures.py
@@ -65,7 +65,6 @@ def test_get_structure_children(
     assert children == expected_children
 
 
-@pytest.mark.xfail  # TODO: remove after get_structure_children bug fix
 @pytest.mark.parametrize(
     ["use_tree"],
     [


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Realised there is still an `xfail` marker in `atlasgen/test_structures` that can be removed now that #552 is merged (this should ideally have been done as part of #543)

**What does this PR do?**

## References
#552 #543

## How has this PR been tested?

## Is this a breaking change?
No. 

## Does this PR require an update to the documentation?
No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
