### PR TITLE
Initial V1.5 implementation

### DIFF
--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -60,6 +60,7 @@ class BrainGlobeAtlas(core.Atlas):
         check_latest=True,
         config_dir=None,
         fn_update=None,
+        v2=False,
     ):
         self.atlas_name = atlas_name
         self.fn_update = fn_update

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -60,7 +60,6 @@ class BrainGlobeAtlas(core.Atlas):
         check_latest=True,
         config_dir=None,
         fn_update=None,
-        v2=False,
     ):
         self.atlas_name = atlas_name
         self.fn_update = fn_update

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -136,6 +136,10 @@ class BrainGlobeAtlas(core.Atlas):
         using name and not version number. If none is found, return None.
         """
         pattern = f"{self.atlas_name}_v*"
+
+        return self._get_local_full_name(pattern)
+
+    def _get_local_full_name(self, pattern: str) -> Optional[str]:
         candidate_dirs = list(self.brainglobe_dir.glob(pattern))
 
         # If multiple folders exist, raise error:
@@ -146,7 +150,7 @@ class BrainGlobeAtlas(core.Atlas):
             )
         # If no one exist, return None:
         elif len(candidate_dirs) == 0:
-            return
+            return None
         # Else, return actual name:
         else:
             return candidate_dirs[0].name

--- a/brainglobe_atlasapi/bg_atlasv2.py
+++ b/brainglobe_atlasapi/bg_atlasv2.py
@@ -1,73 +1,68 @@
-from pathlib import Path
-
 import zarr
 
-from brainglobe_atlasapi import config, core, descriptors
+from brainglobe_atlasapi import BrainGlobeAtlas, descriptors
 
 
-class BrainGlobeAtlasV2(core.Atlas):
+class BrainGlobeAtlasV2(BrainGlobeAtlas):
     atlas_name = None
-    _remote_url_base = descriptors.remote_url_base_v2[0]
+    _remote_url_base = descriptors.remote_url_base_v2
 
     def __init__(
         self,
         atlas_name,
-        brainglobe_dir="/home/igor/.brainglobe-tests/.brainglobe_v2",
-        interm_download_dir="/home/igor/.brainglobe-tests/.brainglobe_v2",
-        check_latest=True,
-        config_dir=None,
-        fn_update=None,
+        **kwargs,
     ):
-        self.atlas_name = atlas_name
-        self.fn_update = fn_update
-
-        # Read BrainGlobe configuration file:
-        conf = config.read_config(config_dir)
-
-        # Use either input locations or locations from the config file,
-        # and create directory if it does not exist:
-        for dir, dirname in zip(
-            [brainglobe_dir, interm_download_dir],
-            ["brainglobe_dir", "interm_download_dir"],
-        ):
-            if dir is None:
-                dir = conf["default_dirs"][dirname]
-
-            # If the default folder does not exist yet, make it:
-            dir_path = Path(dir)
-            dir_path.mkdir(parents=True, exist_ok=True)
-            setattr(self, dirname, dir_path)
-
-        super().__init__(self.brainglobe_dir, self.local_full_name)
+        self._local_full_name = None
+        super().__init__(atlas_name, **kwargs)
 
     @property
     def local_full_name(self):
         """As we can't know the local version a priori, search candidate dirs
         using name and not version number. If none is found, return None.
         """
-        pattern = f"{self.atlas_name}_v*"
-        candidate_dirs = list(self.brainglobe_dir.glob(pattern))
+        if self._local_full_name is None:
+            pattern = f"{self.atlas_name}_v*.json"
+            candidate_dirs = list(self.brainglobe_dir.glob(pattern))
 
-        # If multiple folders exist, raise error:
-        if len(candidate_dirs) > 1:
-            raise FileExistsError(
-                f"Multiple versions of atlas {self.atlas_name} in "
-                f"{self.brainglobe_dir}"
-            )
-        # If no one exist, return None:
-        elif len(candidate_dirs) == 0:
-            return
-        # Else, return actual name:
+            # If multiple folders exist, raise error:
+            if len(candidate_dirs) > 1:
+                raise FileExistsError(
+                    f"Multiple versions of atlas {self.atlas_name} in "
+                    f"{self.brainglobe_dir}"
+                )
+            # If no one exist, return None:
+            elif len(candidate_dirs) == 0:
+                return
+            # Else, return actual name:
+            else:
+                return candidate_dirs[0].name
         else:
-            return candidate_dirs[0].name
+            return self._local_full_name
+
+    @property
+    def local_version(self):
+        """If atlas is local, return actual version of the downloaded files;
+        Else, return none.
+        """
+        version_str = self.metadata["version"]
+
+        if version_str is None:
+            return None
+
+        return tuple(int(version) for version in version_str.split("."))
 
     @property
     def reference(self):
-        reference_path = (
-            self.root_dir
-            / self.metadata["reference_images"][0]
-            / f"{int(self.resolution[0])}um"
-        )
-        zarr_array = zarr.open_array(reference_path, mode="r", zarr_version=3)
+        if self._reference is None:
+            reference_path = (
+                self.root_dir
+                / "templates"
+                / self.metadata["reference_images"][0]
+                / f"{int(self.resolution[0])}um"
+            )
+            zarr_array = zarr.open_array(
+                reference_path, mode="r", zarr_format=3
+            )
+            self._reference = zarr_array[:]
 
-        return zarr_array[:]
+        return self._reference

--- a/brainglobe_atlasapi/bg_atlasv2.py
+++ b/brainglobe_atlasapi/bg_atlasv2.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import zarr
+
+from brainglobe_atlasapi import config, core, descriptors
+
+
+class BrainGlobeAtlasV2(core.Atlas):
+    atlas_name = None
+    _remote_url_base = descriptors.remote_url_base_v2[0]
+
+    def __init__(
+        self,
+        atlas_name,
+        brainglobe_dir="/home/igor/.brainglobe-tests/.brainglobe_v2",
+        interm_download_dir="/home/igor/.brainglobe-tests/.brainglobe_v2",
+        check_latest=True,
+        config_dir=None,
+        fn_update=None,
+    ):
+        self.atlas_name = atlas_name
+        self.fn_update = fn_update
+
+        # Read BrainGlobe configuration file:
+        conf = config.read_config(config_dir)
+
+        # Use either input locations or locations from the config file,
+        # and create directory if it does not exist:
+        for dir, dirname in zip(
+            [brainglobe_dir, interm_download_dir],
+            ["brainglobe_dir", "interm_download_dir"],
+        ):
+            if dir is None:
+                dir = conf["default_dirs"][dirname]
+
+            # If the default folder does not exist yet, make it:
+            dir_path = Path(dir)
+            dir_path.mkdir(parents=True, exist_ok=True)
+            setattr(self, dirname, dir_path)
+
+        super().__init__(self.brainglobe_dir, self.local_full_name)
+
+    @property
+    def local_full_name(self):
+        """As we can't know the local version a priori, search candidate dirs
+        using name and not version number. If none is found, return None.
+        """
+        pattern = f"{self.atlas_name}_v*"
+        candidate_dirs = list(self.brainglobe_dir.glob(pattern))
+
+        # If multiple folders exist, raise error:
+        if len(candidate_dirs) > 1:
+            raise FileExistsError(
+                f"Multiple versions of atlas {self.atlas_name} in "
+                f"{self.brainglobe_dir}"
+            )
+        # If no one exist, return None:
+        elif len(candidate_dirs) == 0:
+            return
+        # Else, return actual name:
+        else:
+            return candidate_dirs[0].name
+
+    @property
+    def reference(self):
+        reference_path = (
+            self.root_dir
+            / self.metadata["reference_images"][0]
+            / f"{int(self.resolution[0])}um"
+        )
+        zarr_array = zarr.open_array(reference_path, mode="r", zarr_version=3)
+
+        return zarr_array[:]

--- a/brainglobe_atlasapi/bg_atlasv2.py
+++ b/brainglobe_atlasapi/bg_atlasv2.py
@@ -1,12 +1,15 @@
 import tarfile
 from pathlib import Path
+from typing import Union
 
 import zarr
 
 from brainglobe_atlasapi import BrainGlobeAtlas, descriptors, utils
+from brainglobe_atlasapi.descriptors import STRUCTURES_FILENAME
 from brainglobe_atlasapi.utils import (
     check_gin_status,
     check_internet_connection,
+    read_json,
 )
 
 
@@ -28,8 +31,17 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
         using name and not version number. If none is found, return None.
         """
         if self._local_full_name is None:
-            pattern = f"{self.atlas_name}_v*.json"
+            # Create the v2 atlases directory if it doesn't exist
+            if not (self.brainglobe_dir / "atlases").exists():
+                (self.brainglobe_dir / "atlases").mkdir(
+                    parents=True, exist_ok=True
+                )
+
+            pattern = f"atlases/{self.atlas_name}_v*.json"
             self._local_full_name = self._get_local_full_name(pattern)
+            # Prepend the atlases directory to the local full name
+            if self._local_full_name is not None:
+                self._local_full_name = "atlases/" + self._local_full_name
 
         return self._local_full_name
 
@@ -92,10 +104,13 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
     def download_tar_file(self, url: str, local_path: Path):
         """Download and extract a file from a URL."""
         # Implement the download and extraction logic here
-        destination_path = self.interm_download_dir / local_path.with_suffix(
-            ".tar.gz"
+        destination_path = (
+            self.interm_download_dir / local_path.with_suffix(".tar.gz").name
         )
+
         utils.retrieve_over_http(url, destination_path, self.fn_update)
+        # Create the directory if it doesn't exist
+        local_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Uncompress the downloaded file
         tar = tarfile.open(destination_path)
@@ -118,16 +133,120 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
         """Download and extract atlas from remote url."""
         check_internet_connection()
         check_gin_status()
+        # Cache to avoid multiple requests
+        remote_version = self.remote_version
 
         name = (
-            f"{self.atlas_name}_v{self.remote_version[0]}."
-            f"{self.remote_version[1]}.json"
+            f"{self.atlas_name}_v{remote_version[0]}."
+            f"{remote_version[1]}.json"
         )
 
         # Get path to folder where data will be saved
-        destination_path = self.brainglobe_dir / name
+        destination_path = self.brainglobe_dir / "atlases" / name
 
         # Try to download atlas data
         utils.retrieve_over_http(
             self.remote_url, destination_path, self.fn_update
         )
+
+        # Check if component directories exist, if not create them
+        self.metadata = read_json(destination_path)
+        annotations_dir = (
+            destination_path.parent
+            / "annotations"
+            / self.metadata["annotation_images"][0]
+        )
+        template_dir = (
+            destination_path.parent
+            / "templates"
+            / self.metadata["reference_images"][0]
+        )
+        meshes_dir = (
+            destination_path.parent / "meshes" / self.metadata["meshes"][0]
+        )
+
+        if not annotations_dir.exists():
+            annotations_dir.mkdir(parents=True, exist_ok=True)
+        if not template_dir.exists():
+            template_dir.mkdir(parents=True, exist_ok=True)
+        if not meshes_dir.exists():
+            meshes_dir.mkdir(parents=True, exist_ok=True)
+
+        structures_path = (
+            destination_path.parent
+            / "annotations"
+            / annotations_dir
+            / STRUCTURES_FILENAME
+        )
+        structures_csv = STRUCTURES_FILENAME.split(".")[0] + ".csv"
+        if not structures_path.exists():
+            remote_url = self._remote_url_base.format(
+                f"{annotations_dir.name}/{STRUCTURES_FILENAME}"
+            )
+            utils.retrieve_over_http(remote_url, structures_path)
+
+        if not structures_path.with_suffix(".csv").exists():
+            remote_url = self._remote_url_base.format(
+                f"{annotations_dir.name}/{structures_csv}"
+            )
+            utils.retrieve_over_http(
+                remote_url, structures_path.with_suffix(".csv")
+            )
+
+    def _get_from_structure(self, structure, key):
+        """
+        Internal interface to the structure dict. It supports querying with a
+        single structure id or a list of ids.
+
+        Parameters
+        ----------
+        structure : int or str or list
+            Valid id or acronym, or list of ids or acronyms.
+        key : str
+            Key for the Structure dictionary (eg "name" or "rgb_triplet").
+
+        Returns
+        -------
+        value or list of values
+            If structure is a list, returns list.
+        """
+        # Check if mesh is cached
+        if key == "mesh":
+            if isinstance(structure, list) or isinstance(structure, tuple):
+                for s in structure:
+                    self._check_mesh_cached(s)
+            else:
+                self._check_mesh_cached(structure)
+
+        return super()._get_from_structure(structure, key)
+
+    def _check_mesh_cached(self, structure: Union[str, int]):
+        """Check if the mesh is cached in the local directory.
+        Download from the remote if not cached.
+
+        Parameters
+        ----------
+        structure : str or int
+            Name of the mesh file.
+
+        Returns
+        -------
+        bool
+            True if the mesh is cached, False otherwise.
+        """
+        mesh_path = Path(self._get_from_structure(structure, "mesh_filename"))
+
+        try:
+            mesh_id = int(structure)
+        except ValueError:
+            mesh_id = int(self.structures.acronym_to_id_map[structure])
+
+        # Check if the mesh is cached
+        if not mesh_path.exists():
+            # If not cached, download it
+            remote_path = self._remote_url_base.format(
+                f"{self.metadata['meshes'][0]}/{mesh_id}.obj"
+            )
+            utils.retrieve_over_http(remote_path, mesh_path)
+
+        return

--- a/brainglobe_atlasapi/bg_atlasv2.py
+++ b/brainglobe_atlasapi/bg_atlasv2.py
@@ -62,6 +62,7 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
     @property
     def template(self):
         if self._template is None:
+            print("Downloading template image...")
             template_path = (
                 self.root_dir
                 / "templates"
@@ -89,6 +90,7 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
     @property
     def annotation(self):
         if self._annotation is None:
+            print("Downloading annotation image...")
             annotation_path = (
                 self.root_dir
                 / "annotations"
@@ -249,6 +251,8 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
         # Check if the mesh is cached
         if not mesh_path.exists():
             # If not cached, download it
+            structure_name = self.structures[mesh_id]["acronym"]
+            print(f"Downloading mesh for {structure_name}...")
             remote_path = self._remote_url_base.format(
                 f"{self.metadata['meshes'][0]}/{mesh_id}.obj"
             )

--- a/brainglobe_atlasapi/bg_atlasv2.py
+++ b/brainglobe_atlasapi/bg_atlasv2.py
@@ -1,9 +1,9 @@
 import tarfile
 from pathlib import Path
 from typing import Union
-from warnings import deprecated
 
 import zarr
+from typing_extensions import deprecated
 
 from brainglobe_atlasapi import BrainGlobeAtlas, descriptors, utils
 from brainglobe_atlasapi.descriptors import STRUCTURES_FILENAME

--- a/brainglobe_atlasapi/bg_atlasv2.py
+++ b/brainglobe_atlasapi/bg_atlasv2.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Union
 
 import zarr
+from brainglobe_utils.IO.yaml import open_yaml
 from pooch import Untar, create
 from typing_extensions import deprecated
 
@@ -10,7 +11,6 @@ from brainglobe_atlasapi.descriptors import STRUCTURES_FILENAME
 from brainglobe_atlasapi.utils import (
     check_gin_status,
     check_internet_connection,
-    read_json,
 )
 
 
@@ -46,7 +46,7 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
                 parents=True, exist_ok=True
             )
 
-            pattern = f"atlases/{self.atlas_name}_v*.json"
+            pattern = f"atlases/{self.atlas_name}_v*.yaml"
             self._local_full_name = self._get_local_full_name(pattern)
             # Prepend the atlases directory to the local full name
             if self._local_full_name is not None:
@@ -136,7 +136,7 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
         if self.remote_version is not None:
             name = (
                 f"{self.atlas_name}_v{self.remote_version[0]}."
-                f"{self.remote_version[1]}.json"
+                f"{self.remote_version[1]}.yaml"
             )
 
             return self._remote_url_base.format(name)
@@ -150,7 +150,7 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
 
         name = (
             f"{self.atlas_name}_v{remote_version[0]}."
-            f"{remote_version[1]}.json"
+            f"{remote_version[1]}.yaml"
         )
 
         # Get path to folder where data will be saved
@@ -169,7 +169,7 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
         self.pooch.fetch(name, progressbar=True)
 
         # Check if component directories exist, if not create them
-        self.metadata = read_json(destination_path)
+        self.metadata = open_yaml(destination_path)
         annotations_dir = (
             destination_path.parent
             / "annotations"

--- a/brainglobe_atlasapi/bg_atlasv2.py
+++ b/brainglobe_atlasapi/bg_atlasv2.py
@@ -172,12 +172,10 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
             destination_path.parent / "meshes" / self.metadata["meshes"][0]
         )
 
-        if not annotations_dir.exists():
-            annotations_dir.mkdir(parents=True, exist_ok=True)
-        if not template_dir.exists():
-            template_dir.mkdir(parents=True, exist_ok=True)
-        if not meshes_dir.exists():
-            meshes_dir.mkdir(parents=True, exist_ok=True)
+        # Create the directories if they don't exist
+        annotations_dir.mkdir(parents=True, exist_ok=True)
+        template_dir.mkdir(parents=True, exist_ok=True)
+        meshes_dir.mkdir(parents=True, exist_ok=True)
 
         structures_path = (
             destination_path.parent

--- a/brainglobe_atlasapi/bg_atlasv2.py
+++ b/brainglobe_atlasapi/bg_atlasv2.py
@@ -22,22 +22,9 @@ class BrainGlobeAtlasV2(BrainGlobeAtlas):
         """
         if self._local_full_name is None:
             pattern = f"{self.atlas_name}_v*.json"
-            candidate_dirs = list(self.brainglobe_dir.glob(pattern))
+            self._local_full_name = self._get_local_full_name(pattern)
 
-            # If multiple folders exist, raise error:
-            if len(candidate_dirs) > 1:
-                raise FileExistsError(
-                    f"Multiple versions of atlas {self.atlas_name} in "
-                    f"{self.brainglobe_dir}"
-                )
-            # If no one exist, return None:
-            elif len(candidate_dirs) == 0:
-                return
-            # Else, return actual name:
-            else:
-                return candidate_dirs[0].name
-        else:
-            return self._local_full_name
+        return self._local_full_name
 
     @property
     def local_version(self):

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from brainglobe_space import AnatomicalSpace
+from brainglobe_utils.IO.yaml import open_yaml
 
 from brainglobe_atlasapi.descriptors import (
     ANNOTATION_FILENAME,
@@ -39,9 +40,9 @@ class Atlas:
             structures_list = read_json(self.root_dir / STRUCTURES_FILENAME)
             meshes_dir = MESHES_DIRNAME
         # v2
-        elif atlas_path.suffix == ".json":
+        elif atlas_path.suffix == ".yaml":
             self.root_dir = atlas_path.parent
-            self.metadata = read_json(atlas_path)
+            self.metadata = open_yaml(atlas_path)
             structures_path = self.metadata["annotation_images"][0]
             structures_list = read_json(
                 self.root_dir

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -1,7 +1,6 @@
 import warnings
 from collections import UserDict
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -31,23 +30,26 @@ class Atlas:
     left_hemisphere_value = 1
     right_hemisphere_value = 2
 
-    def __init__(self, path, metadata_name: Optional[str] = None):
-        self.root_dir = Path(path)
-
+    def __init__(self, path):
+        atlas_path = Path(path)
         # v1
-        if metadata_name is None:
+        if atlas_path.is_dir():
+            self.root_dir = atlas_path
             self.metadata = read_json(self.root_dir / METADATA_FILENAME)
-            # Load structures list:
             structures_list = read_json(self.root_dir / STRUCTURES_FILENAME)
             meshes_dir = MESHES_DIRNAME
         # v2
-        else:
-            self.metadata = read_json(self.root_dir / metadata_name)
+        elif atlas_path.suffix == ".json":
+            self.root_dir = atlas_path.parent
+            self.metadata = read_json(atlas_path)
             structures_path = self.metadata["annotation_images"][0]
             structures_list = read_json(
-                self.root_dir / structures_path / STRUCTURES_FILENAME
+                self.root_dir
+                / "annotations"
+                / structures_path
+                / STRUCTURES_FILENAME
             )
-            meshes_dir = self.metadata["meshes"][0]
+            meshes_dir = "meshes/" + self.metadata["meshes"][0]
 
         # keep to generate tree and dataframe views when necessary
         self.structures_list = structures_list

--- a/brainglobe_atlasapi/descriptors.py
+++ b/brainglobe_atlasapi/descriptors.py
@@ -2,6 +2,10 @@ import numpy as np
 
 # Base url of the gin repository:
 remote_url_base = "https://gin.g-node.org/brainglobe/atlases/raw/master/{}"
+remote_url_base_v2 = [
+    "dropbox://NIU/data/brainglobe-atlasapi-v2/{}",
+    "https://gin.g-node.org/IgorTatarnikov/atlases-v2/raw/master/{}",
+]
 
 # Major version of atlases used by current brainglobe-atlasapi release:
 ATLAS_MAJOR_V = 0

--- a/brainglobe_atlasapi/descriptors.py
+++ b/brainglobe_atlasapi/descriptors.py
@@ -2,10 +2,9 @@ import numpy as np
 
 # Base url of the gin repository:
 remote_url_base = "https://gin.g-node.org/brainglobe/atlases/raw/master/{}"
-remote_url_base_v2 = [
-    "dropbox://NIU/data/brainglobe-atlasapi-v2/{}",
-    "https://gin.g-node.org/IgorTatarnikov/atlases-v2/raw/master/{}",
-]
+remote_url_base_v2 = (
+    "https://gin.g-node.org/brainglobe/atlases-v2/raw/master/{}"
+)
 
 # Major version of atlases used by current brainglobe-atlasapi release:
 ATLAS_MAJOR_V = 0

--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -8,6 +8,7 @@ from typing import Callable, Optional
 
 import requests
 import tifffile
+from pooch import retrieve
 from rich.panel import Panel
 from rich.pretty import Pretty
 from rich.progress import (
@@ -245,6 +246,42 @@ def retrieve_over_http(
         raise requests.exceptions.ConnectionError(
             f"Could not download file from {url}"
         )
+
+
+def retrieve_over_http_pooch(
+    url: str,
+    output_file_path: Path,
+    fn_update: Optional[Callable[[int, int], None]] = None,
+    progress_bar: bool = True,
+) -> None:
+    """
+    Download file from the remote location using pooch. Progress bar shown
+    by default. fn_update is not implemented for pooch, and will throw a
+    warning.
+
+    Parameters
+    ----------
+    url : str
+        Remote URL.
+    output_file_path : Path
+        Full path for download location (including file name)
+    fn_update : Callable[[int, int], None]
+        Handler function to update during download. Takes completed and
+        total bytes. Not implemented for pooch, will throw a warning.
+        Default is None.
+    progress_bar : bool
+        If True, show default pooch progress bar. Default is True.
+    """
+    if fn_update is not None:
+        print("Warning: fn_update is not implemented for pooch.")
+
+    retrieve(
+        url=url,
+        known_hash=None,
+        fname=output_file_path.name,
+        path=output_file_path.parent,
+        progressbar=progress_bar,
+    )
 
 
 def get_download_size(url: str) -> int:

--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -8,7 +8,6 @@ from typing import Callable, Optional
 
 import requests
 import tifffile
-from pooch import retrieve
 from rich.panel import Panel
 from rich.pretty import Pretty
 from rich.progress import (
@@ -246,42 +245,6 @@ def retrieve_over_http(
         raise requests.exceptions.ConnectionError(
             f"Could not download file from {url}"
         )
-
-
-def retrieve_over_http_pooch(
-    url: str,
-    output_file_path: Path,
-    fn_update: Optional[Callable[[int, int], None]] = None,
-    progress_bar: bool = True,
-) -> None:
-    """
-    Download file from the remote location using pooch. Progress bar shown
-    by default. fn_update is not implemented for pooch, and will throw a
-    warning.
-
-    Parameters
-    ----------
-    url : str
-        Remote URL.
-    output_file_path : Path
-        Full path for download location (including file name)
-    fn_update : Callable[[int, int], None]
-        Handler function to update during download. Takes completed and
-        total bytes. Not implemented for pooch, will throw a warning.
-        Default is None.
-    progress_bar : bool
-        If True, show default pooch progress bar. Default is True.
-    """
-    if fn_update is not None:
-        print("Warning: fn_update is not implemented for pooch.")
-
-    retrieve(
-        url=url,
-        known_hash=None,
-        fname=output_file_path.name,
-        path=output_file_path.parent,
-        progressbar=progress_bar,
-    )
 
 
 def get_download_size(url: str) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "rich >= 9.0.0",
     "tifffile",
     "treelib",
+    "zarr >= 3.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,13 @@ dependencies = [
     "meshio",
     "numpy",
     "pandas",
+    "pooch",
     "pyarrow",
     "requests",
     "rich >= 9.0.0",
     "tifffile",
     "treelib",
+    "tqdm",
     "zarr >= 3.0",
 ]
 dynamic = ["version"]
@@ -67,7 +69,6 @@ atlasgen = [
     "vedo",
     "xmltodict",
     "brainglobe-utils",
-    "pooch"
 ]
 
 [project.scripts]

--- a/tests/atlasapi/test_bg_atlasv2.py
+++ b/tests/atlasapi/test_bg_atlasv2.py
@@ -31,12 +31,10 @@ def test_bg_atlasv2_init(v1_atlas, v2_atlas):
     assert v2_atlas.interm_download_dir == MOCK_V2_DIRECTORY
 
 
-@pytest.mark.xfail
 def test_local_version(v1_atlas, v2_atlas):
     assert v2_atlas.local_version == v1_atlas.local_version
 
 
-@pytest.mark.xfail
 def test_remote_version(v1_atlas, v2_atlas):
     assert v2_atlas.remote_version == v1_atlas.remote_version
 
@@ -45,22 +43,20 @@ def test_local_full_name(v1_atlas, v2_atlas):
     assert v2_atlas.local_full_name == "allen_mouse_25um_v1.2.json"
 
 
-# @pytest.mark.xfail
-# def test_remote_url(v1_atlas, v2_atlas):
-#     assert v2_atlas.remote_url == v1_atlas.remote_url
-
-
-# @pytest.mark.xfail
-# def test_check_latest_version(v1_atlas, v2_atlas):
-#     assert v2_atlas.check_latest_version() == v1_atlas.check_latest_version()
-
-
 @pytest.mark.xfail
+def test_remote_url(v1_atlas, v2_atlas):
+    # remote URL for v2 not implemented yet
+    assert v2_atlas.remote_url == v1_atlas.remote_url
+
+
+def test_check_latest_version(v1_atlas, v2_atlas):
+    assert v2_atlas.check_latest_version() == v1_atlas.check_latest_version()
+
+
 def test_repr(v1_atlas, v2_atlas):
     assert repr(v2_atlas) == repr(v1_atlas)
 
 
-@pytest.mark.xfail
 def test_str(v1_atlas, v2_atlas):
     assert str(v2_atlas) == str(v1_atlas)
 

--- a/tests/atlasapi/test_bg_atlasv2.py
+++ b/tests/atlasapi/test_bg_atlasv2.py
@@ -55,7 +55,7 @@ def test_str(v1_atlas, v2_atlas):
 
 
 def test_reference(v1_atlas, v2_atlas):
-    assert np.array_equal(v2_atlas.reference, v1_atlas.reference)
+    assert np.array_equal(v2_atlas.template, v1_atlas.reference)
 
 
 def test_annotation(v1_atlas, v2_atlas):

--- a/tests/atlasapi/test_bg_atlasv2.py
+++ b/tests/atlasapi/test_bg_atlasv2.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from brainglobe_atlasapi import BrainGlobeAtlas
+from brainglobe_atlasapi.bg_atlasv2 import BrainGlobeAtlasV2
+
+MOCK_V2_DIRECTORY = Path.home() / ".brainglobe-tests" / ".brainglobe_v2"
+
+
+@pytest.fixture(scope="module")
+def v1_atlas():
+    return BrainGlobeAtlas("allen_mouse_25um")
+
+
+@pytest.fixture(scope="module")
+def v2_atlas():
+    return BrainGlobeAtlasV2(
+        "allen_mouse_25um",
+        brainglobe_dir=MOCK_V2_DIRECTORY,
+        interm_download_dir=MOCK_V2_DIRECTORY,
+        check_latest=False,
+    )
+
+
+def test_bg_atlasv2_init(v1_atlas, v2_atlas):
+    assert isinstance(v2_atlas, BrainGlobeAtlasV2)
+    assert v2_atlas.atlas_name == v1_atlas.atlas_name
+    assert v2_atlas.brainglobe_dir == MOCK_V2_DIRECTORY
+    assert v2_atlas.interm_download_dir == MOCK_V2_DIRECTORY
+
+
+@pytest.mark.xfail
+def test_local_version(v1_atlas, v2_atlas):
+    assert v2_atlas.local_version == v1_atlas.local_version
+
+
+@pytest.mark.xfail
+def test_remote_version(v1_atlas, v2_atlas):
+    assert v2_atlas.remote_version == v1_atlas.remote_version
+
+
+def test_local_full_name(v1_atlas, v2_atlas):
+    assert v2_atlas.local_full_name == "allen_mouse_25um_v1.2.json"
+
+
+# @pytest.mark.xfail
+# def test_remote_url(v1_atlas, v2_atlas):
+#     assert v2_atlas.remote_url == v1_atlas.remote_url
+
+
+# @pytest.mark.xfail
+# def test_check_latest_version(v1_atlas, v2_atlas):
+#     assert v2_atlas.check_latest_version() == v1_atlas.check_latest_version()
+
+
+@pytest.mark.xfail
+def test_repr(v1_atlas, v2_atlas):
+    assert repr(v2_atlas) == repr(v1_atlas)
+
+
+@pytest.mark.xfail
+def test_str(v1_atlas, v2_atlas):
+    assert str(v2_atlas) == str(v1_atlas)
+
+
+def test_reference(v1_atlas, v2_atlas):
+    assert np.array_equal(v2_atlas.reference, v1_atlas.reference)

--- a/tests/atlasapi/test_bg_atlasv2.py
+++ b/tests/atlasapi/test_bg_atlasv2.py
@@ -11,13 +11,13 @@ MOCK_V2_DIRECTORY = Path.home() / ".brainglobe-tests" / ".brainglobe_v2"
 
 @pytest.fixture(scope="module")
 def v1_atlas():
-    return BrainGlobeAtlas("allen_mouse_25um")
+    return BrainGlobeAtlas("allen_mouse_100um")
 
 
 @pytest.fixture(scope="module")
 def v2_atlas():
     return BrainGlobeAtlasV2(
-        "allen_mouse_25um",
+        "allen_mouse_100um",
         brainglobe_dir=MOCK_V2_DIRECTORY,
         interm_download_dir=MOCK_V2_DIRECTORY,
         check_latest=False,
@@ -40,12 +40,11 @@ def test_remote_version(v1_atlas, v2_atlas):
 
 
 def test_local_full_name(v1_atlas, v2_atlas):
-    assert v2_atlas.local_full_name == "allen_mouse_25um_v1.2.json"
+    assert v2_atlas.local_full_name == "allen_mouse_100um_v1.2.json"
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="Remote version not implemented yet")
 def test_remote_url(v1_atlas, v2_atlas):
-    # remote URL for v2 not implemented yet
     assert v2_atlas.remote_url == v1_atlas.remote_url
 
 
@@ -63,3 +62,115 @@ def test_str(v1_atlas, v2_atlas):
 
 def test_reference(v1_atlas, v2_atlas):
     assert np.array_equal(v2_atlas.reference, v1_atlas.reference)
+
+
+def test_annotation(v1_atlas, v2_atlas):
+    assert np.array_equal(v2_atlas.annotation, v1_atlas.annotation)
+
+
+def test_atlas_name(v1_atlas, v2_atlas):
+    assert v2_atlas.atlas_name == v1_atlas.atlas_name
+
+
+def test_resolution(v1_atlas, v2_atlas):
+    assert v2_atlas.resolution == v1_atlas.resolution
+
+
+def test_orientation(v1_atlas, v2_atlas):
+    assert v2_atlas.orientation == v1_atlas.orientation
+
+
+def test_shape(v1_atlas, v2_atlas):
+    assert v2_atlas.shape == v1_atlas.shape
+
+
+def test_shape_um(v1_atlas, v2_atlas):
+    assert v2_atlas.shape_um == v1_atlas.shape_um
+
+
+def test_structures(v1_atlas, v2_atlas):
+    assert len(v2_atlas.hierarchy) == len(v1_atlas.hierarchy)
+
+
+def test_lookup_df(v1_atlas, v2_atlas):
+    assert (v2_atlas.lookup_df == v1_atlas.lookup_df).to_numpy().all()
+
+
+def test_hemispheres(v1_atlas, v2_atlas):
+    assert np.array_equal(v2_atlas.hemispheres, v1_atlas.hemispheres)
+
+
+@pytest.mark.parametrize("coords", [(0, 0, 0), (50, 50, 100)])
+def test_hemisphere_from_coords(v1_atlas, v2_atlas, coords):
+    assert v2_atlas.hemisphere_from_coords(
+        coords
+    ) == v1_atlas.hemisphere_from_coords(coords)
+    assert v2_atlas.hemisphere_from_coords(
+        coords, microns=True
+    ) == v1_atlas.hemisphere_from_coords(coords, microns=True)
+    assert v2_atlas.hemisphere_from_coords(
+        coords, as_string=True
+    ) == v1_atlas.hemisphere_from_coords(coords, as_string=True)
+
+
+@pytest.mark.parametrize("coords", [(20, 20, 20), (50, 50, 80)])
+def test_structure_from_coords(v1_atlas, v2_atlas, coords):
+    assert v2_atlas.structure_from_coords(
+        coords
+    ) == v1_atlas.structure_from_coords(coords)
+    assert v2_atlas.structure_from_coords(
+        coords, microns=True
+    ) == v1_atlas.structure_from_coords(coords, microns=True)
+    assert v2_atlas.structure_from_coords(
+        coords, as_acronym=True
+    ) == v1_atlas.structure_from_coords(coords, as_acronym=True)
+
+
+def test_mesh_from_structure(v1_atlas, v2_atlas):
+    structure = "HY"
+    v2_mesh = v2_atlas.mesh_from_structure(structure)
+    v1_mesh = v1_atlas.mesh_from_structure(structure)
+
+    assert len(v2_mesh.points) == len(v1_mesh.points)
+
+
+@pytest.mark.xfail(reason="Meshes are stored in different locations")
+def test_meshfile_from_structure(v1_atlas, v2_atlas):
+    structure = "root"
+    assert v2_atlas.meshfile_from_structure(
+        structure
+    ) == v1_atlas.meshfile_from_structure(structure)
+
+
+def test_root_mesh(v1_atlas, v2_atlas):
+    v2_mesh = v2_atlas.root_mesh()
+    v1_mesh = v1_atlas.root_mesh()
+
+    assert len(v2_mesh.points) == len(v1_mesh.points)
+
+
+@pytest.mark.xfail(reason="Meshes are stored in different locations")
+def test_root_meshfile(v1_atlas, v2_atlas):
+    assert v2_atlas.root_meshfile() == v1_atlas.root_meshfile()
+
+
+def test_get_structure_ancestors(v1_atlas, v2_atlas):
+    structure = "HY"
+    assert v2_atlas.get_structure_ancestors(
+        structure
+    ) == v1_atlas.get_structure_ancestors(structure)
+
+
+def test_get_structure_descendants(v1_atlas, v2_atlas):
+    structure = "HY"
+    assert v2_atlas.get_structure_descendants(
+        structure
+    ) == v1_atlas.get_structure_descendants(structure)
+
+
+def test_get_structure_mask(v1_atlas, v2_atlas):
+    structure = "HY"
+    assert np.array_equal(
+        v2_atlas.get_structure_mask(structure),
+        v1_atlas.get_structure_mask(structure),
+    )

--- a/tests/atlasapi/test_bg_atlasv2.py
+++ b/tests/atlasapi/test_bg_atlasv2.py
@@ -34,11 +34,11 @@ def test_remote_version(v1_atlas, v2_atlas):
 
 
 def test_local_full_name(v1_atlas, v2_atlas):
-    assert v2_atlas.local_full_name == "atlases/allen_mouse_100um_v1.2.json"
+    assert v2_atlas.local_full_name == "atlases/allen_mouse_100um_v1.2.yaml"
 
 
 def test_remote_url(v1_atlas, v2_atlas):
-    remote_url = "https://gin.g-node.org/brainglobe/atlases-v2/raw/master/allen_mouse_100um_v1.2.json"
+    remote_url = "https://gin.g-node.org/brainglobe/atlases-v2/raw/master/allen_mouse_100um_v1.2.yaml"
     assert v2_atlas.remote_url == remote_url
 
 

--- a/tests/atlasapi/test_bg_atlasv2.py
+++ b/tests/atlasapi/test_bg_atlasv2.py
@@ -1,12 +1,8 @@
-from pathlib import Path
-
 import numpy as np
 import pytest
 
 from brainglobe_atlasapi import BrainGlobeAtlas
 from brainglobe_atlasapi.bg_atlasv2 import BrainGlobeAtlasV2
-
-MOCK_V2_DIRECTORY = Path.home() / ".brainglobe-tests" / ".brainglobe_v2"
 
 
 @pytest.fixture(scope="module")
@@ -18,8 +14,6 @@ def v1_atlas():
 def v2_atlas():
     return BrainGlobeAtlasV2(
         "allen_mouse_100um",
-        brainglobe_dir=MOCK_V2_DIRECTORY,
-        interm_download_dir=MOCK_V2_DIRECTORY,
         check_latest=False,
     )
 
@@ -27,8 +21,8 @@ def v2_atlas():
 def test_bg_atlasv2_init(v1_atlas, v2_atlas):
     assert isinstance(v2_atlas, BrainGlobeAtlasV2)
     assert v2_atlas.atlas_name == v1_atlas.atlas_name
-    assert v2_atlas.brainglobe_dir == MOCK_V2_DIRECTORY
-    assert v2_atlas.interm_download_dir == MOCK_V2_DIRECTORY
+    assert v2_atlas.brainglobe_dir == v1_atlas.brainglobe_dir
+    assert v2_atlas.interm_download_dir == v1_atlas.interm_download_dir
 
 
 def test_local_version(v1_atlas, v2_atlas):
@@ -40,12 +34,12 @@ def test_remote_version(v1_atlas, v2_atlas):
 
 
 def test_local_full_name(v1_atlas, v2_atlas):
-    assert v2_atlas.local_full_name == "allen_mouse_100um_v1.2.json"
+    assert v2_atlas.local_full_name == "atlases/allen_mouse_100um_v1.2.json"
 
 
-@pytest.mark.xfail(reason="Remote version not implemented yet")
 def test_remote_url(v1_atlas, v2_atlas):
-    assert v2_atlas.remote_url == v1_atlas.remote_url
+    remote_url = "https://gin.g-node.org/brainglobe/atlases-v2/raw/master/allen_mouse_100um_v1.2.json"
+    assert v2_atlas.remote_url == remote_url
 
 
 def test_check_latest_version(v1_atlas, v2_atlas):
@@ -134,12 +128,10 @@ def test_mesh_from_structure(v1_atlas, v2_atlas):
     assert len(v2_mesh.points) == len(v1_mesh.points)
 
 
-@pytest.mark.xfail(reason="Meshes are stored in different locations")
-def test_meshfile_from_structure(v1_atlas, v2_atlas):
+def test_meshfile_from_structure(v2_atlas):
     structure = "root"
-    assert v2_atlas.meshfile_from_structure(
-        structure
-    ) == v1_atlas.meshfile_from_structure(structure)
+    root_mesh_filename = v2_atlas.structures[997]["mesh_filename"]
+    assert v2_atlas.meshfile_from_structure(structure) == root_mesh_filename
 
 
 def test_root_mesh(v1_atlas, v2_atlas):
@@ -149,9 +141,9 @@ def test_root_mesh(v1_atlas, v2_atlas):
     assert len(v2_mesh.points) == len(v1_mesh.points)
 
 
-@pytest.mark.xfail(reason="Meshes are stored in different locations")
-def test_root_meshfile(v1_atlas, v2_atlas):
-    assert v2_atlas.root_meshfile() == v1_atlas.root_meshfile()
+def test_root_meshfile(v2_atlas):
+    root_mesh_filename = v2_atlas.structures[997]["mesh_filename"]
+    assert v2_atlas.root_meshfile() == root_mesh_filename
 
 
 def test_get_structure_ancestors(v1_atlas, v2_atlas):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def mock_brainglobe_user_folders(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def setup_preexisting_local_atlases():
-    """Automatically setup all tests to have three downloaded atlases
+    """Automatically setup all tests to have two downloaded atlases
     in the test user data."""
     preexisting_atlases = [
         ("example_mouse_100um", "v1.2"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import tempfile
@@ -65,17 +64,6 @@ def setup_preexisting_local_atlases():
             Path.home() / f".brainglobe/{atlas_name}_{version}"
         ):
             _ = BrainGlobeAtlas(atlas_name)
-
-    # mock an additional reference for the example mouse
-    atlas_path = Path.home() / ".brainglobe" / "example_mouse_100um_v1.2"
-    metadata_path = atlas_path / "metadata.json"
-    if metadata_path.exists():
-        with open(metadata_path, "r") as f:
-            metadata = f.read()
-            metadata_dict = json.loads(metadata)
-            metadata_dict["additional_references"] = ["reference"]
-            with open(metadata_path, "w") as f:
-                json.dump(metadata_dict, f, indent=4)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See #562 

**What does this PR do?**
This PR creates a new `BrainGlobeAtlasV2` class that inherits from `BrainGlobeAtlas` and overrides any methods that need to be changed for V1.5 to work.

Downloading an atlas to a fresh `.brainglobe` directory triggers the following:
- Local name for the requested atlas is not found (this specifically checks for the `json` e.g. `allen_mouse_100um_v1.2.json`
- The `json` is fetched from the [GIN](https://gin.g-node.org/BrainGlobe/atlases-v2) repository
- The metadata from the `json` is read, and directories for the annotations, template, and meshes are created
- `structures.json` and `structures.csv` are fetched for the appropriate annotations
- The `BrainGlobeAtlasV2` object is instantiated

The actual annotations and template images are not fetched at this time, nor are the meshes.

When the user requests the annotations or references by calling `atlas.reference` or `atlas.annotation` the respective data is fetched at the correct resolution. Meshes are fetched individually when they are requested for now.

Things that still need attention/discussion:
- Need to add a function/API endpoint to force download all data for a given atlas
- Fetch the meshes in a grouped way some how (parent, and 2 levels of children perhaps?)
- Print/log a warning the first time the annotation/template data is requested to inform the user it has to be downloaded first
- I'm also not a fan of needing to download the `structures.json` and `structures.csv` to instantiate the Atlas object but that would involve more changes to `core.Atlas` which I've tried to avoid for now.
- The function that sets up the atlas is named `download_extract_file` even though we're not longer extracting, this is to keep compatibility with the `__init__` method of `BrainGlobeAtlas`.

## References
#562

## How has this PR been tested?
Added tests that compare the data between a V1 atlas and a V2 atlas where possible.

## Is this a breaking change?
Sort of. All V2 atlases live in a `.brainglobe/atlases` directory, ensuring compatibility with the current V1 layout. However, the cached `last_versions.conf` file is overwritten in the `.brainglobe` directory.

## Does this PR require an update to the documentation?
Will have to come later.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
