### PR TITLE
Use correct directory for downloading atlases on CI

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -40,12 +40,12 @@ jobs:
       matrix:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.12", "3.13"]
-        include:
-          - os: macos-latest
-            python-version: "3.13"
-          - os: windows-latest
-            python-version: "3.13"
+        python-version: ["3.13"]
+#        include:
+#          - os: macos-latest
+#            python-version: "3.13"
+#          - os: windows-latest
+#            python-version: "3.13"
 
     steps:
       - name: Cache atlases
@@ -54,11 +54,12 @@ jobs:
           path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
-          key: brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
-          restore-keys: |
-              brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
-              brainglobe-${{ runner.os }}-
-              brainglobe
+          key: fresh-cache-${{ runner.os }}
+#          key: brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
+#          restore-keys: |
+#              brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
+#              brainglobe-${{ runner.os }}-
+#              brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -61,14 +61,14 @@ jobs:
 #              brainglobe-${{ runner.os }}-
 #              brainglobe
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
           path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
-          key: fresh-cache-${{ runner.os }}
+          key: fresh-cache-${{ runner.os }}-1
 #          key: brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
 #          restore-keys: |
 #              brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -61,6 +61,9 @@ jobs:
 #              brainglobe-${{ runner.os }}-
 #              brainglobe
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -40,12 +40,12 @@ jobs:
       matrix:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
-        python-version: ["3.13"]
-#        include:
-#          - os: macos-latest
-#            python-version: "3.13"
-#          - os: windows-latest
-#            python-version: "3.13"
+        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - os: macos-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.13"
 
     steps:
       - name: Cache atlases
@@ -54,12 +54,11 @@ jobs:
           path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
-          key: fresh-cache-${{ runner.os }}-1
-#          key: brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
-#          restore-keys: |
-#              brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
-#              brainglobe-${{ runner.os }}-
-#              brainglobe
+          key: brainglobe-${{ runner.os }}-
+          restore-keys: |
+              brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
+              brainglobe-${{ runner.os }}-
+              brainglobe
 
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -67,9 +67,6 @@ jobs:
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
           path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually
             ~/.brainglobe
             !~/.brainglobe/atlas.tar.gz
-          key: brainglobe-${{ runner.os }}-
+          key: brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
           restore-keys: |
               brainglobe-${{ runner.os }}-${{ needs.get-week-number.outputs.WEEK_NUMBER }}
               brainglobe-${{ runner.os }}-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,5 +126,8 @@ python =
 extras =
     dev
     atlasgen
+passenv =
+    CI
+    GITHUB_ACTIONS
 commands = pytest -v --color=yes --cov=brainglobe_atlasapi --cov-report=xml
 """

--- a/tests/atlasapi/test_bg_atlas.py
+++ b/tests/atlasapi/test_bg_atlas.py
@@ -4,7 +4,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 import requests
 
-from brainglobe_atlasapi import utils
+from brainglobe_atlasapi import config, utils
 from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas
 
 
@@ -90,12 +90,19 @@ def test_str(atlas, capsys):
 
 
 def test_local_search(tmpdir):
-    brainglobe_dir = tmpdir.mkdir("brainglobe")
+    atlas_file_name = "example_mouse_100um_v1.2"
+    brainglobe_dir = config.get_brainglobe_dir()
+    temp_brainglobe_dir = tmpdir.mkdir("brainglobe")
+    shutil.copytree(
+        brainglobe_dir / atlas_file_name,
+        temp_brainglobe_dir / atlas_file_name,
+        dirs_exist_ok=True,
+    )
     interim_download_dir = tmpdir.mkdir("interim_download")
 
     atlas = BrainGlobeAtlas(
         "example_mouse_100um",
-        brainglobe_dir=brainglobe_dir,
+        brainglobe_dir=temp_brainglobe_dir,
         interm_download_dir=interim_download_dir,
     )
 
@@ -107,6 +114,6 @@ def test_local_search(tmpdir):
 
     with pytest.raises(FileExistsError) as error:
         _ = BrainGlobeAtlas(
-            "example_mouse_100um", brainglobe_dir=brainglobe_dir
+            "example_mouse_100um", brainglobe_dir=temp_brainglobe_dir
         )
     assert "Multiple versions of atlas" in str(error)

--- a/tests/atlasapi/test_utils.py
+++ b/tests/atlasapi/test_utils.py
@@ -258,6 +258,7 @@ def test_conf_from_url_no_connection_no_cache(temp_path, mocker):
         "brainglobe_atlasapi.utils.config.get_brainglobe_dir",
         return_value=temp_path,
     )
+    mocker.patch("brainglobe_atlasapi.utils.sleep")
     with mock.patch("requests.get", autospec=True) as mock_request:
         mock_request.side_effect = requests.ConnectionError()
         with pytest.raises(FileNotFoundError) as e:


### PR DESCRIPTION
I found the issue: https://github.com/brainglobe/brainglobe-atlasapi/blob/638091910cc13ca8093a153beb3dd57f28c714b6/tests/conftest.py#L24-L28 The conditional statement was always true even on CI because the `GITHUB_ACTIONS` env variable wasn't being passed to `tox`. Since we only cache the `.brainglobe` directory it was downloading fresh atlases into a `.brainglobe-tests` directory on each run.

The env variable is now being passed back and the cache is being utilised correctly. It now takes ~12 minutes to run the tests. However, this should be sped up when the cache on main is refreshed with new atlases that have been added to the test suite since the last time the cache was used correctly. We can force a refresh by deleting the `brainglobe-{os}-18` caches on main after this is merged and rerunning the test action.

I've also updated one test where a fresh atlas was being downloaded to use the one we have in the cache. It would be nice to go through the testing suite and ensure we're only downloading a new atlas when required. GIN gets grumpy easily and harshly throttles connections leading to long test times.

Closes #564 