### PR TITLE
fix check_gin_status when GIN server is down

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -167,7 +167,7 @@ def check_gin_status(timeout=5, raise_error=True):
         _ = requests.get(url, timeout=timeout)
 
         return True
-    except requests.ConnectionError as e:
+    except (requests.ConnectionError, requests.exceptions.Timeout) as e:
         error_message = "GIN server is down."
         if not raise_error:
             print(error_message)


### PR DESCRIPTION

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The GIN server is down, and yet the `utils.check_gin_status(raise_error=False)` raises an error.

https://downforeveryoneorjustme.com/gin.g-node.org

**What does this PR do?**

catch an additional timeout error from `requests`
