### PR TITLE
Add additional_references keys on construction

### DIFF
--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -358,14 +358,14 @@ class AdditionalRefDict(UserDict):
             self.data[ref_name] = None
 
     def __getitem__(self, ref_name):
-        if self.data[ref_name] is None:
-            if ref_name not in self.references_list:
-                warnings.warn(
-                    f"No reference named {ref_name} "
-                    f"(available: {self.references_list})"
-                )
-                return None
+        if ref_name not in self.references_list:
+            warnings.warn(
+                f"No reference named {ref_name} "
+                f"(available: {self.references_list})"
+            )
+            return None
 
+        if self.data[ref_name] is None:
             self.data[ref_name] = read_tiff(
                 self.data_path / f"{ref_name}.tiff"
             )

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -354,8 +354,11 @@ class AdditionalRefDict(UserDict):
 
         super().__init__(*args, **kwargs)
 
+        for ref_name in self.references_list:
+            self.data[ref_name] = None
+
     def __getitem__(self, ref_name):
-        if ref_name not in self.keys():
+        if self.data[ref_name] is None:
             if ref_name not in self.references_list:
                 warnings.warn(
                     f"No reference named {ref_name} "

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -55,6 +55,14 @@ def test_additional_ref_dict(temp_path):
         assert add_ref_dict["3"] is None
 
 
+def test_addition_ref_dict_keys_only(temp_path):
+    """Test that AdditionalRefDict can be initialized with keys only."""
+    fake_data = ["1", "2"]
+    add_ref_dict = AdditionalRefDict(fake_data, temp_path)
+
+    assert list(add_ref_dict) == fake_data
+
+
 @pytest.mark.parametrize(
     "stack_name, val",
     [

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -49,7 +49,7 @@ def test_additional_ref_dict(temp_path):
     add_ref_dict = AdditionalRefDict(fake_data.keys(), temp_path)
 
     for k, stack in add_ref_dict.items():
-        assert add_ref_dict[k] == stack
+        assert np.all(add_ref_dict[k] == stack)
 
     with pytest.warns(UserWarning, match="No reference named 3"):
         assert add_ref_dict["3"] is None


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See #583 

**What does this PR do?**
On `AdditionalRefDict` construction all additional references passed in the `references_list` are added to the dict with `None` as the entry. When `__getitem__` is called, it now checks if `self.data[ref_name] is None` to see if the reference has been loaded to memory, if not it opens the additional reference file and saves it in the dict.

## References
Closes #583 

## How has this PR been tested?
All existing tests pass.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Yes. We should document the canonical way to fetch a list of names for the additional references from within the API.

Something like `tuple(atlas.additional_references)`?

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
