### PR TITLE
[588]: Removing function that doesnt exist, passing resolution directly for now

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -253,7 +253,7 @@ def wrapup_atlas_from_data(
         atlas_link=atlas_link,
         species=species,
         symmetric=symmetric,
-        resolution=resolution, # We expect input to be asr
+        resolution=resolution,  # We expect input to be asr
         orientation=descriptors.ATLAS_ORIENTATION,  # Pass orientation "asr"
         version=f"{ATLAS_VERSION}.{atlas_minor_version}",
         shape=shape,

--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -246,10 +246,6 @@ def wrapup_atlas_from_data(
     with open(dest_dir / descriptors.STRUCTURES_FILENAME, "w") as f:
         json.dump(structures_list, f)
 
-    final_resolution = space_convention.map_resolution(
-        descriptors.ATLAS_ORIENTATION, resolution
-    )
-
     # Finalize metadata dictionary:
     metadata_dict = generate_metadata_dict(
         name=atlas_name,
@@ -257,7 +253,7 @@ def wrapup_atlas_from_data(
         atlas_link=atlas_link,
         species=species,
         symmetric=symmetric,
-        resolution=final_resolution,  # Pass resolution mapped to ASR
+        resolution=resolution, # We expect input to be asr
         orientation=descriptors.ATLAS_ORIENTATION,  # Pass orientation "asr"
         version=f"{ATLAS_VERSION}.{atlas_minor_version}",
         shape=shape,


### PR DESCRIPTION
## Description

Removing function that doesn't exist, passing resolution directly for now. 

Warning: This could cause issues if the resolution is passed in an incorrect order. This issue propagates to [brainglobe-registration](https://github.com/brainglobe/brainglobe-registration/blob/a799f834b68ac0c29e99cb6718e2f75a898be8e5/brainglobe_registration/registration_widget.py#L708-L722) now as well since the ASR resolution is out of order in the scaling.

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

It was calling a method that doesn't exist.

**What does this PR do?**

## References

#587 

## How has this PR been tested?

Run locally.

## Is this a breaking change?

It could? @alessandrofelder if you could confirm that there are no cases this would break, that'd be awesome.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
