### PR TITLE
A small functionality added to annotation_utils.py together with a new test for it.

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/annotation_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/annotation_utils.py
@@ -3,22 +3,28 @@
 from pathlib import Path
 
 
-def split_label_text(name: str) -> str:
+def split_label_text(name: str, acronym_length=1) -> str:
     """Split label text into name + acronym.
 
     If the label text ends with ')', extract the acronym inside parentheses.
-    Otherwise, use the first letter as the acronym.
+    Otherwise, you can specify  how many first letters
+    you would like to use as acronym
     """
     if name.endswith(")"):
         name, acronym = name.split("(")
         name = name[:-1]  # ignore trailing space
         acronym = acronym[:-1]  # ignore trailing )
     else:
-        acronym = name[0]
+        if acronym_length > len(name):
+            raise ValueError(
+                "Acronym length cannot be longer than the name itself."
+            )
+        else:
+            acronym = name[:acronym_length]
     return name, acronym
 
 
-def read_itk_labels(path: Path) -> dict:
+def read_itk_labels(path: Path, acronym_length=1) -> dict:
     """Turn ITK label data from a file into a list of dictionaries."""
     labels = []
     with open(path) as labels_file:
@@ -31,7 +37,9 @@ def read_itk_labels(path: Path) -> dict:
                     raw_values[7] = raw_values[7][:-1]
                 label_text = raw_values[7][1:-1]
                 if label_text != "Clear Label":
-                    name, acronym = split_label_text(label_text)
+                    name, acronym = split_label_text(
+                        label_text, acronym_length
+                    )
                     labels.append(
                         {
                             "id": id,

--- a/tests/atlasgen/test_annotation_utils.py
+++ b/tests/atlasgen/test_annotation_utils.py
@@ -13,37 +13,46 @@ from brainglobe_atlasapi.atlas_generation.annotation_utils import (
 )
 
 
-@pytest.mark.parametrize(
-    "input_name, expected_name, expected_acronym",
-    [
-        pytest.param(
-            "BrainGlobeAtlas Name (BGA-N)",
-            "BrainGlobeAtlas Name",
-            "BGA-N",
-            id="name (acronym)",
-        ),
-        pytest.param(
-            "BrainGlobeAtlas Name", "BrainGlobeAtlas Name", "B", id="name"
-        ),
-    ],
-)
-def test_split_label_text(input_name, expected_name, expected_acronym):
-    """Test splitting label text into name and acronym.
-
-    Uses the name's first letter as acronym if not provided.
-
-    Parameters
-    ----------
-    input_name : str
-        Input string containing the label name and optional acronym.
-    expected_name : str
-        Expected name after splitting.
-    expected_acronym : str
-        Expected acronym after splitting.
-    """
+def test_split_label_text_name_square_acronym_square():
+    """Test splitting label text with acronym in square brackets."""
+    input_name = "BrainGlobeAtlas-Name (BGA-N)"
+    expected_name = "BrainGlobeAtlas-Name"
+    expected_acronym = "BGA-N"
     name, acronym = split_label_text(input_name)
     assert name == expected_name
     assert acronym == expected_acronym
+
+
+def test_split_label_text_no_acronym_length_specified():
+    """Test splitting label text without acronym, default length 1."""
+    input_name = "BrainGlobeAtlas-Name"
+    expected_name = "BrainGlobeAtlas-Name"
+    expected_acronym = "B"
+    name, acronym = split_label_text(input_name)
+    assert name == expected_name
+    assert acronym == expected_acronym
+
+
+def test_split_label_text_acronym_length_specified():
+    """Test splitting label text without acronym, specified length 3."""
+    input_name = "BrainGlobeAtlas-Name"
+    expected_name = "BrainGlobeAtlas-Name"
+    expected_acronym = "Bra"
+    acronym_length = 3
+    name, acronym = split_label_text(input_name, acronym_length)
+    assert name == expected_name
+    assert acronym == expected_acronym
+
+
+def test_split_label_text_acronym_length_too_long():
+    """Test error when acronym length exceeds name length."""
+    input_name = "BrainGlobeAtlas-Name"
+    acronym_length = len(input_name) + 1
+    with pytest.raises(ValueError) as exc_info:
+        split_label_text(input_name, acronym_length)
+    assert "Acronym length cannot be longer than the name itself." in str(
+        exc_info.value
+    )
 
 
 @pytest.fixture

--- a/tests/atlasgen/test_stacks.py
+++ b/tests/atlasgen/test_stacks.py
@@ -1,3 +1,5 @@
+"""Unit tests for stack writing functions."""
+
 import os
 from pathlib import Path
 


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently the read_itk_labels function only supports 1-letter acryonym
**What does this PR do?**
Now it allows the user to choose the number of first letters the user want to use as structure acryonym.

## How has this PR been tested?

Locally

## Is this a breaking change?

no

## Does this PR require an update to the documentation?

no

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
