### PR TITLE
change from imsave to imwrite, updated version requirement for tifffi…

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/stacks.py
+++ b/brainglobe_atlasapi/atlas_generation/stacks.py
@@ -11,7 +11,7 @@ def write_stack(stack, filename):
     filename
 
     """
-    tifffile.imsave(str(filename), stack)
+    tifffile.imwrite(str(filename), stack)
 
 
 def save_reference(stack, output_dir):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyarrow",
     "requests",
     "rich >= 9.0.0",
-    "tifffile",
+    "tifffile>=2018.11.6",
     "treelib",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
 tifffile.imsave() has been completely removed since February 2025. Fortunatley, we have only one spot to fix.
**What does this PR do?**
change to use tifffile.imwrite() instead of imsave and update the version requirement for tifffile(tifffile>=2018.11.6) 

