### PR TITLE
use unit consistently across conditionals in `atlas_name_from_repr`

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -123,7 +123,7 @@ def atlas_name_from_repr(
 ):
     """Generate atlas name given a description."""
     if major_vers is None and minor_vers is None:
-        return f"{name}_{resolution}"
+        return f"{name}_{resolution}{unit}"
     else:
         return f"{name}_{resolution}{unit}_v{major_vers}.{minor_vers}"
 

--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -86,36 +86,29 @@ def atlas_repr_from_name(name):
 
     atlas_name = "_".join(parts)
 
-    # For unspecified version:
+    # For specified version:
     if version_str:
         major_vers, minor_vers = version_str[1:].split(".")
-
-        # For versioned atlases, separate unit from resolution
-        unit = None
-        for res_unit in descriptors.RESOLUTION:
-            if resolution_str.endswith(res_unit):
-                unit = res_unit
-                resolution_str = resolution_str[: -len(res_unit)]
-                break
-
-        result = dict(
-            name=atlas_name,
-            major_vers=major_vers,
-            minor_vers=minor_vers,
-            resolution=resolution_str,
-        )
-        if unit:
-            result["unit"] = unit
-        return result
     else:
         major_vers, minor_vers = None, None
 
-    return dict(
+    # separate unit from resolution
+    unit = None
+    for res_unit in descriptors.RESOLUTION:
+        if resolution_str.endswith(res_unit):
+            unit = res_unit
+            resolution_str = resolution_str[: -len(res_unit)]
+            break
+
+    result = dict(
         name=atlas_name,
         major_vers=major_vers,
         minor_vers=minor_vers,
         resolution=resolution_str,
     )
+    if unit:
+        result["unit"] = unit
+    return result
 
 
 def atlas_name_from_repr(

--- a/tests/atlasapi/test_utils.py
+++ b/tests/atlasapi/test_utils.py
@@ -328,7 +328,7 @@ def test_rich_atlas_metadata_type():
                     "name": "axolotl",
                     "major_vers": None,
                     "minor_vers": None,
-                    "resolution": "1um",
+                    "resolution": 1,
                 },
             },
             id="axolotl_1um",
@@ -353,7 +353,8 @@ def test_rich_atlas_metadata_type():
                     "name": "axolotl",
                     "major_vers": None,
                     "minor_vers": None,
-                    "resolution": "1nm",
+                    "resolution": 1,
+                    "unit": "nm"
                 },
             },
             id="axolotl_1nm",

--- a/tests/atlasapi/test_utils.py
+++ b/tests/atlasapi/test_utils.py
@@ -328,7 +328,8 @@ def test_rich_atlas_metadata_type():
                     "name": "axolotl",
                     "major_vers": None,
                     "minor_vers": None,
-                    "resolution": 1,
+                    "resolution": "1",
+                    "unit": "um"
                 },
             },
             id="axolotl_1um",
@@ -353,7 +354,7 @@ def test_rich_atlas_metadata_type():
                     "name": "axolotl",
                     "major_vers": None,
                     "minor_vers": None,
-                    "resolution": 1,
+                    "resolution": "1",
                     "unit": "nm"
                 },
             },

--- a/tests/atlasapi/test_utils.py
+++ b/tests/atlasapi/test_utils.py
@@ -329,7 +329,7 @@ def test_rich_atlas_metadata_type():
                     "major_vers": None,
                     "minor_vers": None,
                     "resolution": "1",
-                    "unit": "um"
+                    "unit": "um",
                 },
             },
             id="axolotl_1um",
@@ -355,7 +355,7 @@ def test_rich_atlas_metadata_type():
                     "major_vers": None,
                     "minor_vers": None,
                     "resolution": "1",
-                    "unit": "nm"
+                    "unit": "nm",
                 },
             },
             id="axolotl_1nm",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

A small bug is blocking #587 : `atlas_name_from_repr` it _should_ always return a unit in the atlas name representation, but it currently only does so only if you also specify major and minor version.

**What does this PR do?**

Tiny bugfix in utility function used by wrapup: `atlas_name_from_repr` always returns unit irrespective of whether minor and major versions are specified or not, making the behaviour consistent.
