### PR TITLE
[New Atlas]: Adds the Kim Lab unified mouse brain atlas (20 µm isotropic resolution)

### DIFF
--- a/atlas_scripts/kim_mouse_isotropic.py
+++ b/atlas_scripts/kim_mouse_isotropic.py
@@ -9,10 +9,10 @@ atlas in the BrainGlobe format.
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-import nibabel as nib
 import numpy as np
 import pandas as pd
 import pooch
+from brainglobe_utils.IO.image import load_any
 
 from brainglobe_atlasapi.atlas_generation.mesh_utils import (
     construct_meshes_from_annotation,
@@ -111,11 +111,11 @@ def retrieve_reference_and_annotation(
             f"{REFERENCE_FILE} not found in {download_dir}"
         )
     # Load reference volume (nifti -> numpy array)
-    nifti_img = nib.load(download_dir / REFERENCE_FILE)
-    reference = np.asarray(nifti_img.dataobj).squeeze().astype(np.int32)
+    img_array = load_any(download_dir / REFERENCE_FILE)
+    reference = img_array.squeeze().astype(np.int32)
     # Load annotation volume (nifti -> numpy array)
-    nifti_img = nib.load(download_dir / ANNOTATION_FILE)
-    annotation = np.asarray(nifti_img.dataobj).squeeze().astype(np.int32)
+    img_array = load_any(download_dir / ANNOTATION_FILE)
+    annotation = img_array.squeeze().astype(np.int32)
     return reference, annotation
 
 


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The Kim Lab unified mouse brain atlas at 20 µm isotropic resolution is not currently available in the atlas repository.

**What does this PR do?**
Adds the Kim Lab unified mouse brain atlas (20 µm isotropic resolution), including template and annotation volumes in Brainglobe format.

## How has this PR been tested?
The atlas conversion script was run locally and passed the existing atlas generation checks.
The resulting atlas was visually inspected in Napari to confirm correct orientation and anatomical alignment. 

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Yes, updated README.md

## Checklist:

- [X] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
