### PR TITLE
add CArea atlas generation script

### DIFF
--- a/atlas_scripts/carea_mouse.py
+++ b/atlas_scripts/carea_mouse.py
@@ -27,7 +27,7 @@ from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
 # if this is the first time this atlas has been added the value should be 0
 # (minor version is the first number after the decimal point, ie the minor
 # version of 1.2 is 2)
-__version__ = 0
+__version__ = 1
 
 # The expected format is FirstAuthor_SpeciesCommonName, e.g. kleven_rat, or
 # Institution_SpeciesCommonName, e.g. allen_mouse.
@@ -36,7 +36,7 @@ ATLAS_NAME = "carea_mouse"
 # DOI of the most relevant citable document
 # DOI or URL of the most relevant citable document.
 # If no paper/DOI exists, use "unpublished".
-CITATION = "unpublished"
+CITATION = "https://doi.org/10.64898/2026.01.20.700446"
 
 # The scientific name of the species, ie; Rattus norvegicus
 SPECIES = "Mus musculus"


### PR DESCRIPTION
This adds the unpublished Clustered Area (CArea) atlas. There will soon be a preprint and I will update the script with that DOI once this is out. 

I have validated this works in napari and that the template is within the mesh extent. 
<img width="1917" height="1028" alt="image" src="https://github.com/user-attachments/assets/ac9c7145-3bdf-441c-bf54-80629df31a92" />

One thing is it fails a validation function saying that a pixel is more than 10 times the mesh extent. I'm not sure what this is about but it could be a quirk of this atlas, given that the regions are noncontiguous. Everything looks good in napari.
<img width="1175" height="174" alt="image" src="https://github.com/user-attachments/assets/f66fe2ae-61f0-4511-9b16-bb07abbabf71" />
