### PR TITLE
pin vtk to 9.6.0 before GetCells is deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,8 @@ atlasgen = [
     "vedo",
     "xmltodict",
     "pooch",
-    "zarr"
+    "zarr",
+    "vtk<9.6.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
tests have begun failing. I think it is due to a dependancy being updated and us relying on deprecated functions. 