### PR TITLE
Fix config not restored if test_config_edit fails

### DIFF
--- a/tests/atlasapi/test_config_file.py
+++ b/tests/atlasapi/test_config_file.py
@@ -68,7 +68,9 @@ def test_config_edit(tmp_path):
         config.write_config_value("brainglobe_dir", str(new_atlas_dir))
         config_post = config.read_config()
 
-        assert config_post["default_dirs"]["brainglobe_dir"] == str(new_atlas_dir)
+        assert config_post["default_dirs"]["brainglobe_dir"] == str(
+            new_atlas_dir
+        )
 
         atlas = bg_atlas.BrainGlobeAtlas(atlas_name="example_mouse_100um")
         assert atlas.root_dir.parent == new_atlas_dir


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- If ```test_config_edit``` fails before restoring, the config file remains modified, leaving the config in an unexpected state for further tests.

**What does this PR do?**
- Wraps the config modification in a ```try```/```finally``` block to ensure the original config value is always restored, even if the test fails.

## References
- Fixes #767 

## How has this PR been tested?
- Tested locally without any failures.

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
