### PR TITLE
Fix inconsistent atlas version punctuation in listing metadata

### DIFF
--- a/brainglobe_atlasapi/list_atlases.py
+++ b/brainglobe_atlasapi/list_atlases.py
@@ -133,12 +133,13 @@ def get_atlases_lastversions() -> Dict[str, Dict[str, Any]]:
         if name in available_atlases.keys():
             local_version = get_local_atlas_version(name)
             latest = str(available_atlases[name])
+            local_version_dotted = folder_version_to_dotted(local_version)
             atlases[name] = dict(
                 downloaded=True,
                 local=name,
-                version=folder_version_to_dotted(local_version),
+                version=local_version_dotted,
                 latest_version=latest,
-                updated=latest.replace(".", "_") == local_version,
+                updated=local_version_dotted == latest,
             )
     return atlases
 

--- a/brainglobe_atlasapi/list_atlases.py
+++ b/brainglobe_atlasapi/list_atlases.py
@@ -12,6 +12,13 @@ from rich.table import Table
 from brainglobe_atlasapi import config, descriptors, utils
 
 
+def folder_version_to_dotted(version: Optional[str]) -> Optional[str]:
+    """Convert on-disk version folder names (e.g. 3_0) to dotted form (3.0)."""
+    if version is None:
+        return None
+    return version.replace("_", ".")
+
+
 def get_downloaded_atlases() -> List[str]:
     """Get a list of all the downloaded atlases.
 
@@ -114,7 +121,9 @@ def get_atlases_lastversions() -> Dict[str, Dict[str, Any]]:
     Returns
     -------
     dict
-        A dictionary with metadata about already installed atlases.
+        A dictionary with metadata about already installed atlases. The
+        ``version`` and ``latest_version`` fields use the same dotted form
+        (e.g. ``3.0``), matching ``last_versions.conf``.
     """
     available_atlases = get_all_atlases_lastversions()
 
@@ -123,13 +132,13 @@ def get_atlases_lastversions() -> Dict[str, Dict[str, Any]]:
     for name in get_downloaded_atlases():
         if name in available_atlases.keys():
             local_version = get_local_atlas_version(name)
+            latest = str(available_atlases[name])
             atlases[name] = dict(
                 downloaded=True,
                 local=name,
-                version=local_version,
-                latest_version=str(available_atlases[name]),
-                updated=str(available_atlases[name]).replace(".", "_")
-                == local_version,
+                version=folder_version_to_dotted(local_version),
+                latest_version=latest,
+                updated=latest.replace(".", "_") == local_version,
             )
     return atlases
 
@@ -255,8 +264,8 @@ def add_atlas_to_row(
         downloaded,
         updated,
         (
-            "[#c4c4c4]" + info["version"].replace("_", ".")
-            if "-" not in info["version"]
+            "[#c4c4c4]" + info["version"]
+            if info["version"] and "-" not in info["version"]
             else ""
         ),
         "[#c4c4c4]" + info["latest_version"],

--- a/tests/atlasapi/test_list_atlases.py
+++ b/tests/atlasapi/test_list_atlases.py
@@ -11,12 +11,20 @@ from brainglobe_atlasapi import config, utils
 from brainglobe_atlasapi.atlas_name import AtlasName
 from brainglobe_atlasapi.list_atlases import (
     add_atlas_to_row,
+    folder_version_to_dotted,
     get_all_atlases_lastversions,
     get_atlases_lastversions,
     get_downloaded_atlases,
     get_local_atlas_version,
     show_atlases,
 )
+
+
+def test_folder_version_to_dotted():
+    """Test conversion from folder-style version to dotted version."""
+    assert folder_version_to_dotted("3_0") == "3.0"
+    assert folder_version_to_dotted("5_2") == "5.2"
+    assert folder_version_to_dotted(None) is None
 
 
 def test_get_downloaded_atlases():
@@ -55,12 +63,13 @@ def test_lastversions():
 
     local_v = get_local_atlas_version("example_mouse_100um")
 
-    assert example_atlas["version"] == local_v
+    assert example_atlas["version"] == local_v.replace("_", ".")
     assert all(
         [
             int(last) <= int(r)
             for last, r in zip(
-                example_atlas["latest_version"].split("."), local_v.split(".")
+                example_atlas["latest_version"].split("."),
+                local_v.replace("_", ".").split("."),
             )
         ]
     )

--- a/tests/atlasapi/test_list_atlases.py
+++ b/tests/atlasapi/test_list_atlases.py
@@ -73,6 +73,9 @@ def test_lastversions():
             )
         ]
     )
+    assert example_atlas["updated"] == (
+        example_atlas["version"] == example_atlas["latest_version"]
+    )
 
 
 def test_show_atlases():


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`get_atlases_lastversions()` currently returns inconsistent version formatting in its metadata:

- `version` may be returned as folder-style (e.g. `3_0`)
- `latest_version` is returned in dotted form (e.g. `3.0`)

This makes the output inconsistent and can affect downstream display logic.

**What does this PR do?**

This PR normalises local atlas version metadata to dotted form so that `version` and `latest_version` use the same format.

It also:

- adds a small helper to convert folder-style versions to dotted form
- updates tests to cover the conversion and returned metadata
- updates the relevant docstring to reflect the behaviour
- keeps existing placeholder/missing-version display logic intact, while safely handling `None` versions in table rendering

## References

Closes #787

## How has this PR been tested?

Tested locally by running:

- `pytest tests/atlasapi/test_list_atlases.py -v`
- `ruff check brainglobe_atlasapi/list_atlases.py tests/atlasapi/test_list_atlases.py`
- `pre-commit run --files brainglobe_atlasapi/list_atlases.py tests/atlasapi/test_list_atlases.py`

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No external documentation update is required.  
A small inline docstring update was added to clarify that returned version metadata is normalised to dotted form.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)