### PR TITLE
skip writing empty meshes

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -242,7 +242,9 @@ def wrapup_atlas_from_data(
 
     for mesh_id, meshfile in meshes_dict.items():
         mesh = mio.read(meshfile)
-
+        # do not write empty meshes as this causes wrapup to crash
+        if len(mesh.points) == 0:
+            continue
         if scale_meshes:
             # Scale the mesh to the desired resolution, BEFORE transforming:
             # Note that this transformation happens in original space,


### PR DESCRIPTION
This prevents wrapup from writing meshes which have no points. Doing this crashes the wrapup so it seems wise to avoid. We already skip generating meshes which are under a certain size so this seems to be consistent. 