### PR TITLE
JRC2018Unisex Fly Brain Atlas

### DIFF
--- a/atlas_scripts/jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/jrc2018u_neuropils_fly.py
@@ -1,0 +1,339 @@
+"""Atlas generation script for the JRC2018Unisex Neuropils Fly atlas."""
+
+import json
+from pathlib import Path
+
+import pooch
+
+from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
+from brainglobe_atlasapi.utils import atlas_name_from_repr
+
+### Metadata
+__version__ = 0
+
+ATLAS_NAME = "jrc2018u_neuropils_fly"
+
+CITATION = (
+    "Bogovic et al. 2020, "
+    "https://doi.org/10.1371/journal.pone.0236495"
+)
+
+SPECIES = "Drosophila melanogaster"
+
+ATLAS_LINK = (
+    "https://www.virtualflybrain.org/blog/2022/01/01/"
+    "jrc-2018-templates-rois-jrc2018/"
+)
+
+ATLAS_FILE_URL = (
+    "https://www.virtualflybrain.org/data/VFB/i/0010/1567/"
+    "VFB_00101567/volume.nrrd"
+)
+
+VFB_TEMPLATE_ID = "VFB_00101567"
+
+VFB_SOLR_TERM_INFO_URL = (
+    "http://solr.virtualflybrain.org/solr/vfb_json/select"
+    f"?q=id:{VFB_TEMPLATE_ID}&fl=id,term_info&rows=1&wt=json"
+)
+
+ORIENTATION = "lps"
+
+ROOT_ID = 999
+RESOLUTION = (0.5189161, 0.5189161, 1.0)  # microns
+
+ATLAS_PACKAGER = "Amirreza Bahramani"
+
+
+def _secure_url(url):
+    """Use HTTPS for VFB data files when available."""
+    return url.replace(
+        "http://www.virtualflybrain.org",
+        "https://www.virtualflybrain.org",
+    )
+
+
+def _retrieve(url, download_dir, file_name):
+    return Path(
+        pooch.retrieve(
+            url=url,
+            known_hash=None,
+            path=download_dir,
+            fname=file_name,
+            progressbar=True,
+        )
+    )
+
+
+def _load_vfb_term_info(term_info_response_path):
+    with open(term_info_response_path, encoding="utf-8") as f:
+        response = json.load(f)
+
+    docs = response["response"]["docs"]
+    if not docs:
+        raise RuntimeError(f"No VFB term-info record found for {VFB_TEMPLATE_ID}")
+
+    term_info = docs[0]["term_info"]
+    if isinstance(term_info, list):
+        term_info = term_info[0]
+
+    return json.loads(term_info)
+
+
+def download_resources():
+    """
+    Download the necessary resources for the atlas.
+
+    If possible, please use the Pooch library to retrieve any resources.
+
+    Returns
+    -------
+    dict[str, pathlib.Path]
+        Paths to the downloaded VFB template, ROI masks, and mesh files.
+    """
+    download_dir = (
+        Path.home()
+        / "brainglobe_workingdir"
+        / ATLAS_NAME
+        / "source_data"
+    )
+    roi_volumes_dir = download_dir / "roi_volumes"
+    meshes_dir = download_dir / "meshes"
+
+    download_dir.mkdir(parents=True, exist_ok=True)
+    roi_volumes_dir.mkdir(exist_ok=True)
+    meshes_dir.mkdir(exist_ok=True)
+
+    term_info_response_path = _retrieve(
+        VFB_SOLR_TERM_INFO_URL,
+        download_dir,
+        "jrc2018u_term_info_response.json",
+    )
+    term_info = _load_vfb_term_info(term_info_response_path)
+
+    term_info_path = download_dir / "jrc2018u_term_info.json"
+    with open(term_info_path, "w", encoding="utf-8") as f:
+        json.dump(term_info, f, indent=2)
+
+    template_channel = term_info["template_channel"]
+    reference_url = _secure_url(
+        template_channel.get("image_nrrd") or ATLAS_FILE_URL
+    )
+    reference_path = _retrieve(
+        reference_url,
+        download_dir,
+        "jrc2018u_template.nrrd",
+    )
+
+    root_mesh_path = _retrieve(
+        _secure_url(template_channel["image_obj"]),
+        meshes_dir,
+        f"{ROOT_ID}.obj",
+    )
+
+    roi_volumes = {}
+    meshes = {ROOT_ID: root_mesh_path}
+    domain_metadata = []
+
+    domains = sorted(
+        term_info["template_domains"],
+        key=lambda domain: int(domain["index"][0]),
+    )
+    for domain in domains:
+        vfb_index = int(domain["index"][0])
+        if vfb_index == 0:
+            continue
+
+        structure_id = vfb_index
+        vfb_id = domain["anatomical_individual"]["short_form"]
+
+        roi_volumes[structure_id] = _retrieve(
+            _secure_url(domain["image_nrrd"]),
+            roi_volumes_dir,
+            f"{structure_id}.nrrd",
+        )
+        meshes[structure_id] = _retrieve(
+            _secure_url(domain["image_obj"]),
+            meshes_dir,
+            f"{structure_id}.obj",
+        )
+
+        domain_metadata.append(
+            {
+                "id": structure_id,
+                "vfb_id": vfb_id,
+                "label": domain["anatomical_individual"]["label"],
+                "type_id": domain["anatomical_type"]["short_form"],
+                "type_label": domain["anatomical_type"]["label"],
+                "nrrd": str(roi_volumes[structure_id]),
+                "obj": str(meshes[structure_id]),
+            }
+        )
+
+    domain_metadata_path = download_dir / "jrc2018u_domain_metadata.json"
+    with open(domain_metadata_path, "w", encoding="utf-8") as f:
+        json.dump(domain_metadata, f, indent=2)
+
+    return {
+        "reference": reference_path,
+        "term_info": term_info_path,
+        "domain_metadata": domain_metadata_path,
+        "roi_volumes": roi_volumes,
+        "meshes": meshes,
+    }
+
+
+if __name__ == "__main__":
+    download_resources()
+
+
+def retrieve_reference_and_annotation():
+    """
+    Retrieve the reference and annotation volumes.
+
+    If possible, use brainglobe_utils.IO.image.load_any for opening images.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, numpy.ndarray]
+        A tuple containing the reference volume and the annotation volume.
+    """
+    reference = None
+    annotation = None
+    return reference, annotation
+
+
+def retrieve_hemisphere_map():
+    """
+    Retrieve a hemisphere map for the atlas.
+
+    Use a hemisphere map if the atlas is asymmetrical. This map is an array
+    with the same shape as the template, where 0 marks the left hemisphere
+    and 1 marks the right.
+
+    Returns
+    -------
+    np.ndarray or None
+        A numpy array representing the hemisphere map, or None if the atlas
+        is symmetrical.
+    """
+    return None
+
+
+def retrieve_structure_information():
+    """
+    Return a list of dictionaries with information about the atlas.
+
+    Returns a list of dictionaries, where each dictionary represents a
+    structure and contains its ID, name, acronym, hierarchical path,
+    and RGB triplet.
+
+    The expected format for each dictionary is:
+
+    .. code-block:: python
+
+        {
+            "id": int,
+            "name": str,
+            "acronym": str,
+            "structure_id_path": list[int],
+            "rgb_triplet": list[int, int, int],
+        }
+
+    Returns
+    -------
+    list[dict]
+        A list of dictionaries, each containing information for a single
+        atlas structure.
+    """
+    return None
+
+
+def retrieve_or_construct_meshes():
+    """
+    Return a dictionary mapping structure IDs to paths of mesh files.
+
+    If the atlas is packaged with mesh files, download and use them. Otherwise,
+    construct the meshes using available helper functions.
+
+    Returns
+    -------
+    dict
+        A dictionary where keys are structure IDs and values are paths to the
+        corresponding mesh files.
+    """
+    meshes_dict = {}
+    return meshes_dict
+
+
+def retrieve_additional_references():
+    """
+    Return a dictionary of additional reference images.
+
+    This function should be edited only if the atlas includes additional
+    reference images. The dictionary should map the name of each additional
+    reference image to its corresponding image stack data.
+
+    Returns
+    -------
+    dict
+        A dictionary mapping reference image names to their image stack data.
+    """
+    additional_references = {}
+    return additional_references
+
+
+
+
+
+
+
+
+
+
+
+
+# ### If the code above this line has been filled correctly, nothing needs to be
+# ### edited below (unless variables need to be passed between the functions).
+# if __name__ == "__main__":
+#     if RESOLUTION is None:
+#         raise ValueError("RESOLUTION must be set before running this script.")
+
+#     bg_root_dir = Path.home() / "brainglobe_workingdir" / ATLAS_NAME
+#     bg_root_dir.mkdir(parents=True, exist_ok=True)
+
+#     # Fail early if any version of this atlas already exists
+#     atlas_prefix = atlas_name_from_repr(ATLAS_NAME, RESOLUTION)
+#     existing = list(bg_root_dir.glob(f"{atlas_prefix}_v*"))
+
+#     if existing:
+#         raise FileExistsError(
+#             f"Atlas output already exists in {bg_root_dir}. "
+#         )
+#     download_resources()
+#     reference_volume, annotated_volume = retrieve_reference_and_annotation()
+#     additional_references = retrieve_additional_references()
+#     hemispheres_stack = retrieve_hemisphere_map()
+#     structures = retrieve_structure_information()
+#     meshes_dict = retrieve_or_construct_meshes()
+
+#     output_filename = wrapup_atlas_from_data(
+#         atlas_name=ATLAS_NAME,
+#         atlas_minor_version=__version__,
+#         citation=CITATION,
+#         atlas_link=ATLAS_LINK,
+#         species=SPECIES,
+#         resolution=(RESOLUTION,) * 3,
+#         orientation=ORIENTATION,
+#         root_id=ROOT_ID,
+#         reference_stack=reference_volume,
+#         annotation_stack=annotated_volume,
+#         structures_list=structures,
+#         meshes_dict=meshes_dict,
+#         working_dir=bg_root_dir,
+#         hemispheres_stack=None,
+#         cleanup_files=False,
+#         compress=True,
+#         scale_meshes=True,
+#         additional_references=additional_references,
+#     )

--- a/atlas_scripts/jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/jrc2018u_neuropils_fly.py
@@ -5,17 +5,13 @@ from pathlib import Path
 
 import pooch
 
-from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
-from brainglobe_atlasapi.utils import atlas_name_from_repr
-
 ### Metadata
 __version__ = 0
 
 ATLAS_NAME = "jrc2018u_neuropils_fly"
 
 CITATION = (
-    "Bogovic et al. 2020, "
-    "https://doi.org/10.1371/journal.pone.0236495"
+    "Bogovic et al. 2020, " "https://doi.org/10.1371/journal.pone.0236495"
 )
 
 SPECIES = "Drosophila melanogaster"
@@ -71,7 +67,9 @@ def _load_vfb_term_info(term_info_response_path):
 
     docs = response["response"]["docs"]
     if not docs:
-        raise RuntimeError(f"No VFB term-info record found for {VFB_TEMPLATE_ID}")
+        raise RuntimeError(
+            f"No VFB term-info record found for {VFB_TEMPLATE_ID}"
+        )
 
     term_info = docs[0]["term_info"]
     if isinstance(term_info, list):
@@ -92,10 +90,7 @@ def download_resources():
         Paths to the downloaded VFB template, ROI masks, and mesh files.
     """
     download_dir = (
-        Path.home()
-        / "brainglobe_workingdir"
-        / ATLAS_NAME
-        / "source_data"
+        Path.home() / "brainglobe_workingdir" / ATLAS_NAME / "source_data"
     )
     roi_volumes_dir = download_dir / "roi_volumes"
     meshes_dir = download_dir / "meshes"
@@ -281,16 +276,6 @@ def retrieve_additional_references():
     """
     additional_references = {}
     return additional_references
-
-
-
-
-
-
-
-
-
-
 
 
 # ### If the code above this line has been filled correctly, nothing needs to be

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -4,8 +4,13 @@ import gzip
 import json
 from pathlib import Path
 
+import brainglobe_space as bgs
+import meshio as mio
 import numpy as np
 import pooch
+
+from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
+from brainglobe_atlasapi.utils import atlas_name_from_repr
 
 ### Metadata
 __version__ = 0
@@ -35,10 +40,12 @@ VFB_SOLR_TERM_INFO_URL = (
     f"?q=id:{VFB_TEMPLATE_ID}&fl=id,term_info&rows=1&wt=json"
 )
 
-ORIENTATION = "lps"
+SOURCE_ORIENTATION = "lps"
+SOURCE_RESOLUTION = (0.5189161, 0.5189161, 1.0)  # microns
 
 ROOT_ID = 999
-RESOLUTION = (0.5189161, 0.5189161, 1.0)  # microns
+ORIENTATION = "asr"
+RESOLUTION = (0.5189161, 1.0, 0.5189161)  # microns
 
 ATLAS_PACKAGER = "Amirreza Bahramani"
 
@@ -133,6 +140,30 @@ def _rgb_triplet_from_id(structure_id):
 
 def _acronym_from_domain_label(label):
     return label.split(" on ", maxsplit=1)[0].replace("\\'", "'")
+
+
+def _source_space(source_shape):
+    physical_shape = tuple(
+        size * resolution
+        for size, resolution in zip(source_shape, SOURCE_RESOLUTION)
+    )
+    return bgs.AnatomicalSpace(SOURCE_ORIENTATION, shape=physical_shape)
+
+
+def _map_stack_to_asr(stack):
+    mapped_stack = _source_space(stack.shape).map_stack_to(
+        ORIENTATION, stack, copy=False
+    )
+    return np.ascontiguousarray(mapped_stack)
+
+
+def _map_mesh_to_asr(mesh_path, output_path, source_shape):
+    mesh = mio.read(mesh_path)
+    mesh.points = _source_space(source_shape).map_points_to(
+        ORIENTATION, mesh.points
+    )
+    mio.write(output_path, mesh)
+    return output_path
 
 
 def download_resources():
@@ -270,7 +301,7 @@ def retrieve_reference_and_annotation():
 
         annotation[mask_voxels] = structure_id
 
-    return reference, annotation
+    return _map_stack_to_asr(reference), _map_stack_to_asr(annotation)
 
 
 def retrieve_hemisphere_map():
@@ -349,18 +380,51 @@ def retrieve_structure_information():
 
 def retrieve_or_construct_meshes():
     """
-    Return a dictionary mapping structure IDs to paths of mesh files.
+    Return the VFB mesh files mapped into BrainGlobe ASR space.
 
-    If the atlas is packaged with mesh files, download and use them. Otherwise,
-    construct the meshes using available helper functions.
+    VFB provides OBJ files for this template and each painted ROI, so no mesh
+    construction is needed here.
 
     Returns
     -------
-    dict
+    dict[int, pathlib.Path]
         A dictionary where keys are structure IDs and values are paths to the
         corresponding mesh files.
     """
-    meshes_dict = {}
+    download_dir = (
+        Path.home() / "brainglobe_workingdir" / ATLAS_NAME / "source_data"
+    )
+    domain_metadata_path = download_dir / "jrc2018u_domain_metadata.json"
+    meshes_dir = download_dir / "meshes"
+    asr_meshes_dir = download_dir / "asr_meshes"
+    asr_meshes_dir.mkdir(exist_ok=True)
+
+    with open(domain_metadata_path, encoding="utf-8") as f:
+        domain_metadata = json.load(f)
+
+    source_shape = _load_nrrd_array(
+        download_dir / "jrc2018u_template.nrrd"
+    ).shape
+    root_mesh_path = meshes_dir / f"{ROOT_ID}.obj"
+    if not root_mesh_path.is_file():
+        raise FileNotFoundError(f"Missing root mesh: {root_mesh_path}")
+
+    meshes_dict = {
+        ROOT_ID: _map_mesh_to_asr(
+            root_mesh_path, asr_meshes_dir / f"{ROOT_ID}.obj", source_shape
+        )
+    }
+    domains = sorted(domain_metadata, key=lambda domain: int(domain["id"]))
+    for domain in domains:
+        structure_id = int(domain["id"])
+        mesh_path = Path(domain["obj"])
+        if not mesh_path.is_file():
+            raise FileNotFoundError(f"Missing ROI mesh: {mesh_path}")
+
+        meshes_dict[structure_id] = _map_mesh_to_asr(
+            mesh_path, asr_meshes_dir / f"{structure_id}.obj", source_shape
+        )
+
     return meshes_dict
 
 
@@ -382,52 +446,46 @@ def retrieve_additional_references():
 
 
 if __name__ == "__main__":
+    if RESOLUTION is None:
+        raise ValueError("RESOLUTION must be set before running this script.")
+
+    bg_root_dir = Path.home() / "brainglobe_workingdir" / ATLAS_NAME
+    bg_root_dir.mkdir(parents=True, exist_ok=True)
+
+    atlas_prefix = atlas_name_from_repr(ATLAS_NAME, RESOLUTION[0])
+    existing = list(bg_root_dir.glob(f"{atlas_prefix}_v*"))
+    if existing:
+        raise FileExistsError(
+            f"Atlas output already exists in {bg_root_dir}. "
+            "Move it or delete it before running this script again."
+        )
+
     download_resources()
-    retrieve_reference_and_annotation()
-    retrieve_structure_information()
+    reference_volume, annotated_volume = retrieve_reference_and_annotation()
+    additional_references = retrieve_additional_references()
+    hemispheres_stack = retrieve_hemisphere_map()
+    structures = retrieve_structure_information()
+    meshes_dict = retrieve_or_construct_meshes()
 
-
-# ### If the code above this line has been filled correctly, nothing needs to be
-# ### edited below (unless variables need to be passed between the functions).
-# if __name__ == "__main__":
-#     if RESOLUTION is None:
-#         raise ValueError("RESOLUTION must be set before running this script.")
-
-#     bg_root_dir = Path.home() / "brainglobe_workingdir" / ATLAS_NAME
-#     bg_root_dir.mkdir(parents=True, exist_ok=True)
-
-#     # Fail early if any version of this atlas already exists
-#     atlas_prefix = atlas_name_from_repr(ATLAS_NAME, RESOLUTION)
-#     existing = list(bg_root_dir.glob(f"{atlas_prefix}_v*"))
-
-#     if existing:
-#         raise FileExistsError(
-#             f"Atlas output already exists in {bg_root_dir}. "
-#         )
-#     download_resources()
-#     reference_volume, annotated_volume = retrieve_reference_and_annotation()
-#     additional_references = retrieve_additional_references()
-#     hemispheres_stack = retrieve_hemisphere_map()
-#     structures = retrieve_structure_information()
-#     meshes_dict = retrieve_or_construct_meshes()
-
-#     output_filename = wrapup_atlas_from_data(
-#         atlas_name=ATLAS_NAME,
-#         atlas_minor_version=__version__,
-#         citation=CITATION,
-#         atlas_link=ATLAS_LINK,
-#         species=SPECIES,
-#         resolution=(RESOLUTION,) * 3,
-#         orientation=ORIENTATION,
-#         root_id=ROOT_ID,
-#         reference_stack=reference_volume,
-#         annotation_stack=annotated_volume,
-#         structures_list=structures,
-#         meshes_dict=meshes_dict,
-#         working_dir=bg_root_dir,
-#         hemispheres_stack=None,
-#         cleanup_files=False,
-#         compress=True,
-#         scale_meshes=True,
-#         additional_references=additional_references,
-#     )
+    output_filename = wrapup_atlas_from_data(
+        atlas_name=ATLAS_NAME,
+        atlas_minor_version=__version__,
+        citation=CITATION,
+        atlas_link=ATLAS_LINK,
+        species=SPECIES,
+        resolution=RESOLUTION,
+        orientation=ORIENTATION,
+        root_id=ROOT_ID,
+        reference_stack=reference_volume,
+        annotation_stack=annotated_volume,
+        structures_list=structures,
+        meshes_dict=meshes_dict,
+        working_dir=bg_root_dir,
+        atlas_packager=ATLAS_PACKAGER,
+        hemispheres_stack=hemispheres_stack,
+        cleanup_files=False,
+        compress=True,
+        scale_meshes=False,
+        additional_references=additional_references,
+    )
+    print(f"Atlas packaged: {output_filename}")

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -126,6 +126,15 @@ def _load_nrrd_array(nrrd_path):
     return np.frombuffer(data, dtype=dtype).reshape(sizes, order="F")
 
 
+def _rgb_triplet_from_id(structure_id):
+    value = (structure_id * 2654435761) % (2**32)
+    return [50 + ((value >> shift) % 180) for shift in (16, 8, 0)]
+
+
+def _acronym_from_domain_label(label):
+    return label.split(" on ", maxsplit=1)[0].replace("\\'", "'")
+
+
 def download_resources():
     """
     Download the necessary resources for the atlas.
@@ -283,11 +292,8 @@ def retrieve_hemisphere_map():
 
 def retrieve_structure_information():
     """
-    Return a list of dictionaries with information about the atlas.
+    Return a flat list of atlas structures.
 
-    Returns a list of dictionaries, where each dictionary represents a
-    structure and contains its ID, name, acronym, hierarchical path,
-    and RGB triplet.
 
     The expected format for each dictionary is:
 
@@ -307,7 +313,38 @@ def retrieve_structure_information():
         A list of dictionaries, each containing information for a single
         atlas structure.
     """
-    return None
+    download_dir = (
+        Path.home() / "brainglobe_workingdir" / ATLAS_NAME / "source_data"
+    )
+    domain_metadata_path = download_dir / "jrc2018u_domain_metadata.json"
+
+    with open(domain_metadata_path, encoding="utf-8") as f:
+        domain_metadata = json.load(f)
+
+    structures = [
+        {
+            "id": ROOT_ID,
+            "name": "JRC2018Unisex adult brain",
+            "acronym": "root",
+            "structure_id_path": [ROOT_ID],
+            "rgb_triplet": [255, 255, 255],
+        }
+    ]
+
+    domains = sorted(domain_metadata, key=lambda domain: int(domain["id"]))
+    for domain in domains:
+        structure_id = int(domain["id"])
+        structures.append(
+            {
+                "id": structure_id,
+                "name": domain["type_label"],
+                "acronym": _acronym_from_domain_label(domain["label"]),
+                "structure_id_path": [ROOT_ID, structure_id],
+                "rgb_triplet": _rgb_triplet_from_id(structure_id),
+            }
+        )
+
+    return structures
 
 
 def retrieve_or_construct_meshes():
@@ -347,6 +384,7 @@ def retrieve_additional_references():
 if __name__ == "__main__":
     download_resources()
     retrieve_reference_and_annotation()
+    retrieve_structure_information()
 
 
 # ### If the code above this line has been filled correctly, nothing needs to be

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -1,4 +1,4 @@
-"""Atlas generation script for the JRC2018Unisex Neuropils Fly atlas."""
+"""Atlas generation script for the VFB's JRC2018Unisex Neuropils Fly atlas."""
 
 import json
 from pathlib import Path
@@ -8,7 +8,7 @@ import pooch
 ### Metadata
 __version__ = 0
 
-ATLAS_NAME = "jrc2018u_neuropils_fly"
+ATLAS_NAME = "vfb_jrc2018u_neuropils_fly"
 
 CITATION = (
     "Bogovic et al. 2020, " "https://doi.org/10.1371/journal.pone.0236495"
@@ -81,8 +81,6 @@ def _load_vfb_term_info(term_info_response_path):
 def download_resources():
     """
     Download the necessary resources for the atlas.
-
-    If possible, please use the Pooch library to retrieve any resources.
 
     Returns
     -------

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -1,8 +1,10 @@
 """Atlas generation script for the VFB's JRC2018Unisex Neuropils Fly atlas."""
 
+import gzip
 import json
 from pathlib import Path
 
+import numpy as np
 import pooch
 
 ### Metadata
@@ -76,6 +78,52 @@ def _load_vfb_term_info(term_info_response_path):
         term_info = term_info[0]
 
     return json.loads(term_info)
+
+
+def _load_nrrd_array(nrrd_path):
+    """Load a gzip-encoded NRRD file into a numpy array."""
+    nrrd_path = Path(nrrd_path)
+    file_bytes = nrrd_path.read_bytes()
+
+    header_end = file_bytes.find(b"\n\n")
+    separator_length = 2
+    if header_end == -1:
+        header_end = file_bytes.find(b"\r\n\r\n")
+        separator_length = 4
+
+    if header_end == -1:
+        raise ValueError(f"Could not find NRRD header end in {nrrd_path}")
+
+    header = file_bytes[:header_end].decode("ascii")
+    data = file_bytes[header_end + separator_length :]
+
+    header_fields = {}
+    for line in header.splitlines():
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+
+        key, value = line.split(":", maxsplit=1)
+        header_fields[key.strip()] = value.strip()
+
+    sizes = tuple(int(size) for size in header_fields["sizes"].split())
+    data_type = header_fields["type"]
+    encoding = header_fields.get("encoding", "raw").lower()
+
+    if encoding in {"gzip", "gz"}:
+        data = gzip.decompress(data)
+    elif encoding != "raw":
+        raise ValueError(f"Unsupported NRRD encoding: {encoding}")
+
+    dtype = {
+        "uint8": np.uint8,
+        "uchar": np.uint8,
+        "unsigned char": np.uint8,
+        "uint16": np.uint16,
+        "ushort": np.uint16,
+        "unsigned short": np.uint16,
+    }[data_type]
+
+    return np.frombuffer(data, dtype=dtype).reshape(sizes, order="F")
 
 
 def download_resources():
@@ -176,23 +224,43 @@ def download_resources():
     }
 
 
-if __name__ == "__main__":
-    download_resources()
-
-
 def retrieve_reference_and_annotation():
     """
     Retrieve the reference and annotation volumes.
-
-    If possible, use brainglobe_utils.IO.image.load_any for opening images.
 
     Returns
     -------
     tuple[numpy.ndarray, numpy.ndarray]
         A tuple containing the reference volume and the annotation volume.
     """
-    reference = None
-    annotation = None
+    download_dir = (
+        Path.home() / "brainglobe_workingdir" / ATLAS_NAME / "source_data"
+    )
+    reference_path = download_dir / "jrc2018u_template.nrrd"
+    roi_volumes_dir = download_dir / "roi_volumes"
+
+    reference = _load_nrrd_array(reference_path)
+    annotation = np.zeros(reference.shape, dtype=np.uint16)
+
+    roi_paths = sorted(
+        roi_volumes_dir.glob("*.nrrd"),
+        key=lambda path: int(path.stem),
+    )
+    for roi_path in roi_paths:
+        structure_id = int(roi_path.stem)
+        roi_mask = _load_nrrd_array(roi_path)
+        if roi_mask.shape != reference.shape:
+            raise ValueError(
+                f"ROI {structure_id} has shape {roi_mask.shape}, "
+                f"but reference has shape {reference.shape}"
+            )
+
+        mask_voxels = roi_mask > 0
+        if np.any(annotation[mask_voxels] != 0):
+            raise ValueError(f"ROI {structure_id} overlaps another ROI")
+
+        annotation[mask_voxels] = structure_id
+
     return reference, annotation
 
 
@@ -274,6 +342,11 @@ def retrieve_additional_references():
     """
     additional_references = {}
     return additional_references
+
+
+if __name__ == "__main__":
+    download_resources()
+    retrieve_reference_and_annotation()
 
 
 # ### If the code above this line has been filled correctly, nothing needs to be

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -11,27 +11,19 @@ import pooch
 import SimpleITK as sitk
 
 from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
-from brainglobe_atlasapi.utils import atlas_name_from_repr
 
 ### Metadata
 __version__ = 0
 
 ATLAS_NAME = "vfb_jrc2018u_neuropils_fly"
 
-CITATION = (
-    "Bogovic et al. 2020, " "https://doi.org/10.1371/journal.pone.0236495"
-)
+CITATION = "Bogovic et al. 2020, https://doi.org/10.1371/journal.pone.0236495"
 
 SPECIES = "Drosophila melanogaster"
 
 ATLAS_LINK = (
     "https://www.virtualflybrain.org/blog/2022/01/01/"
     "jrc-2018-templates-rois-jrc2018/"
-)
-
-ATLAS_FILE_URL = (
-    "https://www.virtualflybrain.org/data/VFB/i/0010/1567/"
-    "VFB_00101567/volume.nrrd"
 )
 
 VFB_TEMPLATE_ID = "VFB_00101567"
@@ -116,16 +108,7 @@ def download_resources():
     with open(term_info_response_path, encoding="utf-8") as f:
         response = json.load(f)
 
-    docs = response["response"]["docs"]
-    if not docs:
-        raise RuntimeError(
-            f"No VFB term-info record found for {VFB_TEMPLATE_ID}"
-        )
-
-    term_info = docs[0]["term_info"]
-    if isinstance(term_info, list):
-        term_info = term_info[0]
-    term_info = json.loads(term_info)
+    term_info = json.loads(response["response"]["docs"][0]["term_info"][0])
 
     term_info_path = SOURCE_DATA_DIR / "jrc2018u_term_info.json"
     with open(term_info_path, "w", encoding="utf-8") as f:
@@ -133,7 +116,7 @@ def download_resources():
 
     template_channel = term_info["template_channel"]
     # VFB metadata may use a clear-text scheme; force HTTPS for downloads.
-    reference_url = template_channel.get("image_nrrd") or ATLAS_FILE_URL
+    reference_url = template_channel["image_nrrd"]
     reference_url = urlsplit(reference_url)._replace(scheme="https").geturl()
     _retrieve(
         reference_url,
@@ -206,16 +189,7 @@ def retrieve_reference_and_annotation():
     for roi_path in roi_paths:
         structure_id = int(roi_path.stem)
         roi_mask = _load_nrrd_array(roi_path)
-        if roi_mask.shape != reference.shape:
-            raise ValueError(
-                f"ROI {structure_id} has shape {roi_mask.shape}, "
-                f"but reference has shape {reference.shape}"
-            )
-
         mask_voxels = roi_mask > 0
-        if np.any(annotation[mask_voxels] != 0):
-            raise ValueError(f"ROI {structure_id} overlaps another ROI")
-
         annotation[mask_voxels] = structure_id
 
     return _map_stack_to_asr(reference), _map_stack_to_asr(annotation)
@@ -271,9 +245,6 @@ def retrieve_or_construct_meshes():
 
     source_shape = _load_nrrd_array(REFERENCE_PATH).shape
     root_mesh_path = MESHES_DIR / f"{ROOT_ID}.obj"
-    if not root_mesh_path.is_file():
-        raise FileNotFoundError(f"Missing root mesh: {root_mesh_path}")
-
     meshes_dict = {
         ROOT_ID: _map_mesh_to_asr(
             root_mesh_path, ASR_MESHES_DIR / f"{ROOT_ID}.obj", source_shape
@@ -283,9 +254,6 @@ def retrieve_or_construct_meshes():
     for domain in domains:
         structure_id = int(domain["id"])
         mesh_path = Path(domain["obj"])
-        if not mesh_path.is_file():
-            raise FileNotFoundError(f"Missing ROI mesh: {mesh_path}")
-
         meshes_dict[structure_id] = _map_mesh_to_asr(
             mesh_path, ASR_MESHES_DIR / f"{structure_id}.obj", source_shape
         )
@@ -300,14 +268,6 @@ def retrieve_additional_references():
 
 if __name__ == "__main__":
     BG_ROOT_DIR.mkdir(parents=True, exist_ok=True)
-
-    atlas_prefix = atlas_name_from_repr(ATLAS_NAME, RESOLUTION[0])
-    existing = list(BG_ROOT_DIR.glob(f"{atlas_prefix}_v*"))
-    if existing:
-        raise FileExistsError(
-            f"Atlas output already exists in {BG_ROOT_DIR}. "
-            "Move it or delete it before running this script again."
-        )
 
     download_resources()
     reference_volume, annotated_volume = retrieve_reference_and_annotation()

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import brainglobe_space as bgs
 import meshio as mio
@@ -41,11 +42,11 @@ VFB_SOLR_TERM_INFO_URL = (
 )
 
 SOURCE_ORIENTATION = "lps"
-SOURCE_RESOLUTION = (0.5189161, 0.5189161, 1.0)  # microns
+SOURCE_RESOLUTION = (0.5189161, 0.5189161, 1.0)  # Exact VFB NRRD spacing
 
 ROOT_ID = 999
 ORIENTATION = "asr"
-RESOLUTION = (0.5189161, 1.0, 0.5189161)  # microns
+RESOLUTION = (0.519, 1.0, 0.519)  # microns
 
 ATLAS_PACKAGER = "Amirreza Bahramani"
 
@@ -106,9 +107,6 @@ def download_resources():
     SOURCE_DATA_DIR.mkdir(parents=True, exist_ok=True)
     ROI_VOLUMES_DIR.mkdir(exist_ok=True)
     MESHES_DIR.mkdir(exist_ok=True)
-    # VFB metadata may list file URLs with http://; download over HTTPS.
-    vfb_http_prefix = "http://www.virtualflybrain.org"
-    vfb_https_prefix = "https://www.virtualflybrain.org"
 
     term_info_response_path = _retrieve(
         VFB_SOLR_TERM_INFO_URL,
@@ -134,23 +132,19 @@ def download_resources():
         json.dump(term_info, f, indent=2)
 
     template_channel = term_info["template_channel"]
-    reference_url = (
-        template_channel.get("image_nrrd") or ATLAS_FILE_URL
-    ).replace(
-        vfb_http_prefix,
-        vfb_https_prefix,
-    )
+    # VFB metadata may use a clear-text scheme; force HTTPS for downloads.
+    reference_url = template_channel.get("image_nrrd") or ATLAS_FILE_URL
+    reference_url = urlsplit(reference_url)._replace(scheme="https").geturl()
     _retrieve(
         reference_url,
         SOURCE_DATA_DIR,
         REFERENCE_PATH.name,
     )
 
+    root_mesh_url = urlsplit(template_channel["image_obj"])
+    root_mesh_url = root_mesh_url._replace(scheme="https").geturl()
     _retrieve(
-        template_channel["image_obj"].replace(
-            vfb_http_prefix,
-            vfb_https_prefix,
-        ),
+        root_mesh_url,
         MESHES_DIR,
         f"{ROOT_ID}.obj",
     )
@@ -168,13 +162,18 @@ def download_resources():
         structure_id = vfb_index
         vfb_id = domain["anatomical_individual"]["short_form"]
 
+        roi_url = urlsplit(domain["image_nrrd"])
+        roi_url = roi_url._replace(scheme="https").geturl()
         roi_path = _retrieve(
-            domain["image_nrrd"].replace(vfb_http_prefix, vfb_https_prefix),
+            roi_url,
             ROI_VOLUMES_DIR,
             f"{structure_id}.nrrd",
         )
+
+        mesh_url = urlsplit(domain["image_obj"])
+        mesh_url = mesh_url._replace(scheme="https").geturl()
         mesh_path = _retrieve(
-            domain["image_obj"].replace(vfb_http_prefix, vfb_https_prefix),
+            mesh_url,
             MESHES_DIR,
             f"{structure_id}.obj",
         )

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -172,7 +172,9 @@ def download_resources():
 
 def retrieve_reference_and_annotation():
     """Load the reference and combine ROI masks into one annotation."""
-    reference = sitk.GetArrayFromImage(sitk.ReadImage(str(REFERENCE_PATH))).transpose(2, 1, 0)
+    reference = sitk.GetArrayFromImage(
+        sitk.ReadImage(str(REFERENCE_PATH))
+    ).transpose(2, 1, 0)
     annotation = np.zeros(reference.shape, dtype=np.uint16)
 
     roi_paths = sorted(
@@ -181,7 +183,9 @@ def retrieve_reference_and_annotation():
     )
     for roi_path in roi_paths:
         structure_id = int(roi_path.stem)
-        roi_mask = sitk.GetArrayFromImage(sitk.ReadImage(str(roi_path))).transpose(2, 1, 0)
+        roi_mask = sitk.GetArrayFromImage(
+            sitk.ReadImage(str(roi_path))
+        ).transpose(2, 1, 0)
         mask_voxels = roi_mask > 0
         annotation[mask_voxels] = structure_id
 
@@ -236,7 +240,11 @@ def retrieve_or_construct_meshes():
     with open(DOMAIN_METADATA_PATH, encoding="utf-8") as f:
         domain_metadata = json.load(f)
 
-    source_shape = sitk.GetArrayFromImage(sitk.ReadImage(str(REFERENCE_PATH))).transpose(2, 1, 0).shape
+    source_shape = (
+        sitk.GetArrayFromImage(sitk.ReadImage(str(REFERENCE_PATH)))
+        .transpose(2, 1, 0)
+        .shape
+    )
     root_mesh_path = MESHES_DIR / f"{ROOT_ID}.obj"
     meshes_dict = {
         ROOT_ID: _map_mesh_to_asr(

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -63,13 +63,6 @@ def _retrieve(url, download_dir, file_name):
     )
 
 
-def _load_nrrd_array(nrrd_path):
-    """Read a VFB NRRD into the x, y, z array order used by this script."""
-    return sitk.GetArrayFromImage(sitk.ReadImage(str(nrrd_path))).transpose(
-        2, 1, 0
-    )
-
-
 def _source_space(source_shape):
     physical_shape = tuple(
         size * resolution
@@ -179,7 +172,7 @@ def download_resources():
 
 def retrieve_reference_and_annotation():
     """Load the reference and combine ROI masks into one annotation."""
-    reference = _load_nrrd_array(REFERENCE_PATH)
+    reference = sitk.GetArrayFromImage(sitk.ReadImage(str(REFERENCE_PATH))).transpose(2, 1, 0)
     annotation = np.zeros(reference.shape, dtype=np.uint16)
 
     roi_paths = sorted(
@@ -188,7 +181,7 @@ def retrieve_reference_and_annotation():
     )
     for roi_path in roi_paths:
         structure_id = int(roi_path.stem)
-        roi_mask = _load_nrrd_array(roi_path)
+        roi_mask = sitk.GetArrayFromImage(sitk.ReadImage(str(roi_path))).transpose(2, 1, 0)
         mask_voxels = roi_mask > 0
         annotation[mask_voxels] = structure_id
 
@@ -243,7 +236,7 @@ def retrieve_or_construct_meshes():
     with open(DOMAIN_METADATA_PATH, encoding="utf-8") as f:
         domain_metadata = json.load(f)
 
-    source_shape = _load_nrrd_array(REFERENCE_PATH).shape
+    source_shape = sitk.GetArrayFromImage(sitk.ReadImage(str(REFERENCE_PATH))).transpose(2, 1, 0).shape
     root_mesh_path = MESHES_DIR / f"{ROOT_ID}.obj"
     meshes_dict = {
         ROOT_ID: _map_mesh_to_asr(

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -72,9 +72,9 @@ def _retrieve(url, download_dir, file_name):
 
 def _load_nrrd_array(nrrd_path):
     """Read a VFB NRRD into the x, y, z array order used by this script."""
-    return sitk.GetArrayFromImage(
-        sitk.ReadImage(str(nrrd_path))
-    ).transpose(2, 1, 0)
+    return sitk.GetArrayFromImage(sitk.ReadImage(str(nrrd_path))).transpose(
+        2, 1, 0
+    )
 
 
 def _source_space(source_shape):
@@ -255,8 +255,7 @@ def retrieve_structure_information():
                 "acronym": domain_acronym,
                 "structure_id_path": [ROOT_ID, structure_id],
                 "rgb_triplet": [
-                    50 + ((color_value >> shift) % 180)
-                    for shift in (16, 8, 0)
+                    50 + ((color_value >> shift) % 180) for shift in (16, 8, 0)
                 ],
             }
         )

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -1,6 +1,5 @@
 """Atlas generation script for the VFB's JRC2018Unisex Neuropils Fly atlas."""
 
-import gzip
 import json
 from pathlib import Path
 
@@ -8,6 +7,7 @@ import brainglobe_space as bgs
 import meshio as mio
 import numpy as np
 import pooch
+import SimpleITK as sitk
 
 from brainglobe_atlasapi.atlas_generation.wrapup import wrapup_atlas_from_data
 from brainglobe_atlasapi.utils import atlas_name_from_repr
@@ -36,7 +36,7 @@ ATLAS_FILE_URL = (
 VFB_TEMPLATE_ID = "VFB_00101567"
 
 VFB_SOLR_TERM_INFO_URL = (
-    "http://solr.virtualflybrain.org/solr/vfb_json/select"
+    "https://solr.virtualflybrain.org/solr/vfb_json/select"
     f"?q=id:{VFB_TEMPLATE_ID}&fl=id,term_info&rows=1&wt=json"
 )
 
@@ -49,13 +49,13 @@ RESOLUTION = (0.5189161, 1.0, 0.5189161)  # microns
 
 ATLAS_PACKAGER = "Amirreza Bahramani"
 
-
-def _secure_url(url):
-    """Use HTTPS for VFB data files when available."""
-    return url.replace(
-        "http://www.virtualflybrain.org",
-        "https://www.virtualflybrain.org",
-    )
+BG_ROOT_DIR = Path.home() / "brainglobe_workingdir" / ATLAS_NAME
+SOURCE_DATA_DIR = BG_ROOT_DIR / "source_data"
+ROI_VOLUMES_DIR = SOURCE_DATA_DIR / "roi_volumes"
+MESHES_DIR = SOURCE_DATA_DIR / "meshes"
+ASR_MESHES_DIR = SOURCE_DATA_DIR / "asr_meshes"
+REFERENCE_PATH = SOURCE_DATA_DIR / "jrc2018u_template.nrrd"
+DOMAIN_METADATA_PATH = SOURCE_DATA_DIR / "jrc2018u_domain_metadata.json"
 
 
 def _retrieve(url, download_dir, file_name):
@@ -70,76 +70,11 @@ def _retrieve(url, download_dir, file_name):
     )
 
 
-def _load_vfb_term_info(term_info_response_path):
-    with open(term_info_response_path, encoding="utf-8") as f:
-        response = json.load(f)
-
-    docs = response["response"]["docs"]
-    if not docs:
-        raise RuntimeError(
-            f"No VFB term-info record found for {VFB_TEMPLATE_ID}"
-        )
-
-    term_info = docs[0]["term_info"]
-    if isinstance(term_info, list):
-        term_info = term_info[0]
-
-    return json.loads(term_info)
-
-
 def _load_nrrd_array(nrrd_path):
-    """Load a gzip-encoded NRRD file into a numpy array."""
-    nrrd_path = Path(nrrd_path)
-    file_bytes = nrrd_path.read_bytes()
-
-    header_end = file_bytes.find(b"\n\n")
-    separator_length = 2
-    if header_end == -1:
-        header_end = file_bytes.find(b"\r\n\r\n")
-        separator_length = 4
-
-    if header_end == -1:
-        raise ValueError(f"Could not find NRRD header end in {nrrd_path}")
-
-    header = file_bytes[:header_end].decode("ascii")
-    data = file_bytes[header_end + separator_length :]
-
-    header_fields = {}
-    for line in header.splitlines():
-        if not line or line.startswith("#") or ":" not in line:
-            continue
-
-        key, value = line.split(":", maxsplit=1)
-        header_fields[key.strip()] = value.strip()
-
-    sizes = tuple(int(size) for size in header_fields["sizes"].split())
-    data_type = header_fields["type"]
-    encoding = header_fields.get("encoding", "raw").lower()
-
-    if encoding in {"gzip", "gz"}:
-        data = gzip.decompress(data)
-    elif encoding != "raw":
-        raise ValueError(f"Unsupported NRRD encoding: {encoding}")
-
-    dtype = {
-        "uint8": np.uint8,
-        "uchar": np.uint8,
-        "unsigned char": np.uint8,
-        "uint16": np.uint16,
-        "ushort": np.uint16,
-        "unsigned short": np.uint16,
-    }[data_type]
-
-    return np.frombuffer(data, dtype=dtype).reshape(sizes, order="F")
-
-
-def _rgb_triplet_from_id(structure_id):
-    value = (structure_id * 2654435761) % (2**32)
-    return [50 + ((value >> shift) % 180) for shift in (16, 8, 0)]
-
-
-def _acronym_from_domain_label(label):
-    return label.split(" on ", maxsplit=1)[0].replace("\\'", "'")
+    """Read a VFB NRRD into the x, y, z array order used by this script."""
+    return sitk.GetArrayFromImage(
+        sitk.ReadImage(str(nrrd_path))
+    ).transpose(2, 1, 0)
 
 
 def _source_space(source_shape):
@@ -167,55 +102,60 @@ def _map_mesh_to_asr(mesh_path, output_path, source_shape):
 
 
 def download_resources():
-    """
-    Download the necessary resources for the atlas.
-
-    Returns
-    -------
-    dict[str, pathlib.Path]
-        Paths to the downloaded VFB template, ROI masks, and mesh files.
-    """
-    download_dir = (
-        Path.home() / "brainglobe_workingdir" / ATLAS_NAME / "source_data"
-    )
-    roi_volumes_dir = download_dir / "roi_volumes"
-    meshes_dir = download_dir / "meshes"
-
-    download_dir.mkdir(parents=True, exist_ok=True)
-    roi_volumes_dir.mkdir(exist_ok=True)
-    meshes_dir.mkdir(exist_ok=True)
+    """Download the VFB template, ROI volumes, meshes, and metadata."""
+    SOURCE_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    ROI_VOLUMES_DIR.mkdir(exist_ok=True)
+    MESHES_DIR.mkdir(exist_ok=True)
+    # VFB metadata may list file URLs with http://; download over HTTPS.
+    vfb_http_prefix = "http://www.virtualflybrain.org"
+    vfb_https_prefix = "https://www.virtualflybrain.org"
 
     term_info_response_path = _retrieve(
         VFB_SOLR_TERM_INFO_URL,
-        download_dir,
+        SOURCE_DATA_DIR,
         "jrc2018u_term_info_response.json",
     )
-    term_info = _load_vfb_term_info(term_info_response_path)
+    with open(term_info_response_path, encoding="utf-8") as f:
+        response = json.load(f)
 
-    term_info_path = download_dir / "jrc2018u_term_info.json"
+    docs = response["response"]["docs"]
+    if not docs:
+        raise RuntimeError(
+            f"No VFB term-info record found for {VFB_TEMPLATE_ID}"
+        )
+
+    term_info = docs[0]["term_info"]
+    if isinstance(term_info, list):
+        term_info = term_info[0]
+    term_info = json.loads(term_info)
+
+    term_info_path = SOURCE_DATA_DIR / "jrc2018u_term_info.json"
     with open(term_info_path, "w", encoding="utf-8") as f:
         json.dump(term_info, f, indent=2)
 
     template_channel = term_info["template_channel"]
-    reference_url = _secure_url(
+    reference_url = (
         template_channel.get("image_nrrd") or ATLAS_FILE_URL
+    ).replace(
+        vfb_http_prefix,
+        vfb_https_prefix,
     )
-    reference_path = _retrieve(
+    _retrieve(
         reference_url,
-        download_dir,
-        "jrc2018u_template.nrrd",
+        SOURCE_DATA_DIR,
+        REFERENCE_PATH.name,
     )
 
-    root_mesh_path = _retrieve(
-        _secure_url(template_channel["image_obj"]),
-        meshes_dir,
+    _retrieve(
+        template_channel["image_obj"].replace(
+            vfb_http_prefix,
+            vfb_https_prefix,
+        ),
+        MESHES_DIR,
         f"{ROOT_ID}.obj",
     )
 
-    roi_volumes = {}
-    meshes = {ROOT_ID: root_mesh_path}
     domain_metadata = []
-
     domains = sorted(
         term_info["template_domains"],
         key=lambda domain: int(domain["index"][0]),
@@ -228,14 +168,14 @@ def download_resources():
         structure_id = vfb_index
         vfb_id = domain["anatomical_individual"]["short_form"]
 
-        roi_volumes[structure_id] = _retrieve(
-            _secure_url(domain["image_nrrd"]),
-            roi_volumes_dir,
+        roi_path = _retrieve(
+            domain["image_nrrd"].replace(vfb_http_prefix, vfb_https_prefix),
+            ROI_VOLUMES_DIR,
             f"{structure_id}.nrrd",
         )
-        meshes[structure_id] = _retrieve(
-            _secure_url(domain["image_obj"]),
-            meshes_dir,
+        mesh_path = _retrieve(
+            domain["image_obj"].replace(vfb_http_prefix, vfb_https_prefix),
+            MESHES_DIR,
             f"{structure_id}.obj",
         )
 
@@ -246,44 +186,22 @@ def download_resources():
                 "label": domain["anatomical_individual"]["label"],
                 "type_id": domain["anatomical_type"]["short_form"],
                 "type_label": domain["anatomical_type"]["label"],
-                "nrrd": str(roi_volumes[structure_id]),
-                "obj": str(meshes[structure_id]),
+                "nrrd": str(roi_path),
+                "obj": str(mesh_path),
             }
         )
 
-    domain_metadata_path = download_dir / "jrc2018u_domain_metadata.json"
-    with open(domain_metadata_path, "w", encoding="utf-8") as f:
+    with open(DOMAIN_METADATA_PATH, "w", encoding="utf-8") as f:
         json.dump(domain_metadata, f, indent=2)
-
-    return {
-        "reference": reference_path,
-        "term_info": term_info_path,
-        "domain_metadata": domain_metadata_path,
-        "roi_volumes": roi_volumes,
-        "meshes": meshes,
-    }
 
 
 def retrieve_reference_and_annotation():
-    """
-    Retrieve the reference and annotation volumes.
-
-    Returns
-    -------
-    tuple[numpy.ndarray, numpy.ndarray]
-        A tuple containing the reference volume and the annotation volume.
-    """
-    download_dir = (
-        Path.home() / "brainglobe_workingdir" / ATLAS_NAME / "source_data"
-    )
-    reference_path = download_dir / "jrc2018u_template.nrrd"
-    roi_volumes_dir = download_dir / "roi_volumes"
-
-    reference = _load_nrrd_array(reference_path)
+    """Load the reference and combine ROI masks into one annotation."""
+    reference = _load_nrrd_array(REFERENCE_PATH)
     annotation = np.zeros(reference.shape, dtype=np.uint16)
 
     roi_paths = sorted(
-        roi_volumes_dir.glob("*.nrrd"),
+        ROI_VOLUMES_DIR.glob("*.nrrd"),
         key=lambda path: int(path.stem),
     )
     for roi_path in roi_paths:
@@ -305,51 +223,13 @@ def retrieve_reference_and_annotation():
 
 
 def retrieve_hemisphere_map():
-    """
-    Retrieve a hemisphere map for the atlas.
-
-    Use a hemisphere map if the atlas is asymmetrical. This map is an array
-    with the same shape as the template, where 0 marks the left hemisphere
-    and 1 marks the right.
-
-    Returns
-    -------
-    np.ndarray or None
-        A numpy array representing the hemisphere map, or None if the atlas
-        is symmetrical.
-    """
+    """Return no hemisphere map because this atlas is treated as symmetric."""
     return None
 
 
 def retrieve_structure_information():
-    """
-    Return a flat list of atlas structures.
-
-
-    The expected format for each dictionary is:
-
-    .. code-block:: python
-
-        {
-            "id": int,
-            "name": str,
-            "acronym": str,
-            "structure_id_path": list[int],
-            "rgb_triplet": list[int, int, int],
-        }
-
-    Returns
-    -------
-    list[dict]
-        A list of dictionaries, each containing information for a single
-        atlas structure.
-    """
-    download_dir = (
-        Path.home() / "brainglobe_workingdir" / ATLAS_NAME / "source_data"
-    )
-    domain_metadata_path = download_dir / "jrc2018u_domain_metadata.json"
-
-    with open(domain_metadata_path, encoding="utf-8") as f:
+    """Return a flat root-plus-domain structure list."""
+    with open(DOMAIN_METADATA_PATH, encoding="utf-8") as f:
         domain_metadata = json.load(f)
 
     structures = [
@@ -365,13 +245,19 @@ def retrieve_structure_information():
     domains = sorted(domain_metadata, key=lambda domain: int(domain["id"]))
     for domain in domains:
         structure_id = int(domain["id"])
+        domain_acronym = domain["label"].split(" on ", maxsplit=1)[0]
+        domain_acronym = domain_acronym.replace("\\'", "'")
+        color_value = (structure_id * 2654435761) % (2**32)
         structures.append(
             {
                 "id": structure_id,
                 "name": domain["type_label"],
-                "acronym": _acronym_from_domain_label(domain["label"]),
+                "acronym": domain_acronym,
                 "structure_id_path": [ROOT_ID, structure_id],
-                "rgb_triplet": _rgb_triplet_from_id(structure_id),
+                "rgb_triplet": [
+                    50 + ((color_value >> shift) % 180)
+                    for shift in (16, 8, 0)
+                ],
             }
         )
 
@@ -379,39 +265,20 @@ def retrieve_structure_information():
 
 
 def retrieve_or_construct_meshes():
-    """
-    Return the VFB mesh files mapped into BrainGlobe ASR space.
+    """Return the VFB mesh files mapped into BrainGlobe ASR space."""
+    ASR_MESHES_DIR.mkdir(exist_ok=True)
 
-    VFB provides OBJ files for this template and each painted ROI, so no mesh
-    construction is needed here.
-
-    Returns
-    -------
-    dict[int, pathlib.Path]
-        A dictionary where keys are structure IDs and values are paths to the
-        corresponding mesh files.
-    """
-    download_dir = (
-        Path.home() / "brainglobe_workingdir" / ATLAS_NAME / "source_data"
-    )
-    domain_metadata_path = download_dir / "jrc2018u_domain_metadata.json"
-    meshes_dir = download_dir / "meshes"
-    asr_meshes_dir = download_dir / "asr_meshes"
-    asr_meshes_dir.mkdir(exist_ok=True)
-
-    with open(domain_metadata_path, encoding="utf-8") as f:
+    with open(DOMAIN_METADATA_PATH, encoding="utf-8") as f:
         domain_metadata = json.load(f)
 
-    source_shape = _load_nrrd_array(
-        download_dir / "jrc2018u_template.nrrd"
-    ).shape
-    root_mesh_path = meshes_dir / f"{ROOT_ID}.obj"
+    source_shape = _load_nrrd_array(REFERENCE_PATH).shape
+    root_mesh_path = MESHES_DIR / f"{ROOT_ID}.obj"
     if not root_mesh_path.is_file():
         raise FileNotFoundError(f"Missing root mesh: {root_mesh_path}")
 
     meshes_dict = {
         ROOT_ID: _map_mesh_to_asr(
-            root_mesh_path, asr_meshes_dir / f"{ROOT_ID}.obj", source_shape
+            root_mesh_path, ASR_MESHES_DIR / f"{ROOT_ID}.obj", source_shape
         )
     }
     domains = sorted(domain_metadata, key=lambda domain: int(domain["id"]))
@@ -422,41 +289,25 @@ def retrieve_or_construct_meshes():
             raise FileNotFoundError(f"Missing ROI mesh: {mesh_path}")
 
         meshes_dict[structure_id] = _map_mesh_to_asr(
-            mesh_path, asr_meshes_dir / f"{structure_id}.obj", source_shape
+            mesh_path, ASR_MESHES_DIR / f"{structure_id}.obj", source_shape
         )
 
     return meshes_dict
 
 
 def retrieve_additional_references():
-    """
-    Return a dictionary of additional reference images.
-
-    This function should be edited only if the atlas includes additional
-    reference images. The dictionary should map the name of each additional
-    reference image to its corresponding image stack data.
-
-    Returns
-    -------
-    dict
-        A dictionary mapping reference image names to their image stack data.
-    """
-    additional_references = {}
-    return additional_references
+    """Return no additional reference images."""
+    return {}
 
 
 if __name__ == "__main__":
-    if RESOLUTION is None:
-        raise ValueError("RESOLUTION must be set before running this script.")
-
-    bg_root_dir = Path.home() / "brainglobe_workingdir" / ATLAS_NAME
-    bg_root_dir.mkdir(parents=True, exist_ok=True)
+    BG_ROOT_DIR.mkdir(parents=True, exist_ok=True)
 
     atlas_prefix = atlas_name_from_repr(ATLAS_NAME, RESOLUTION[0])
-    existing = list(bg_root_dir.glob(f"{atlas_prefix}_v*"))
+    existing = list(BG_ROOT_DIR.glob(f"{atlas_prefix}_v*"))
     if existing:
         raise FileExistsError(
-            f"Atlas output already exists in {bg_root_dir}. "
+            f"Atlas output already exists in {BG_ROOT_DIR}. "
             "Move it or delete it before running this script again."
         )
 
@@ -480,7 +331,7 @@ if __name__ == "__main__":
         annotation_stack=annotated_volume,
         structures_list=structures,
         meshes_dict=meshes_dict,
-        working_dir=bg_root_dir,
+        working_dir=BG_ROOT_DIR,
         atlas_packager=ATLAS_PACKAGER,
         hemispheres_stack=hemispheres_stack,
         cleanup_files=False,

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -295,6 +295,6 @@ if __name__ == "__main__":
         hemispheres_stack=hemispheres_stack,
         scale_meshes=False,
         additional_references=additional_references,
-        overwrite=True
+        overwrite=True,
     )
     print(f"Atlas packaged: {output_filename}")

--- a/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
+++ b/atlas_scripts/vfb_jrc2018u_neuropils_fly.py
@@ -293,9 +293,8 @@ if __name__ == "__main__":
         working_dir=BG_ROOT_DIR,
         atlas_packager=ATLAS_PACKAGER,
         hemispheres_stack=hemispheres_stack,
-        cleanup_files=False,
-        compress=True,
         scale_meshes=False,
         additional_references=additional_references,
+        overwrite=True
     )
     print(f"Atlas packaged: {output_filename}")

--- a/brainglobe_atlasapi/atlas_name.py
+++ b/brainglobe_atlasapi/atlas_name.py
@@ -205,6 +205,7 @@ AtlasName: TypeAlias = Literal[
     "sju_cavefish_2um",
     "swc_female_rat_50um",
     "unam_axolotl_40um",
+    "vfb_jrc2018u_neuropils_fly_0.5189161um",
     "whs_sd_rat_39um",
     "whs_sd_swc_female_rat_39um",
 ]

--- a/brainglobe_atlasapi/atlas_name.py
+++ b/brainglobe_atlasapi/atlas_name.py
@@ -205,7 +205,7 @@ AtlasName: TypeAlias = Literal[
     "sju_cavefish_2um",
     "swc_female_rat_50um",
     "unam_axolotl_40um",
-    "vfb_jrc2018u_neuropils_fly_0.5189161um",
+    "vfb_jrc2018u_neuropils_fly_0.519um",
     "whs_sd_rat_39um",
     "whs_sd_swc_female_rat_39um",
 ]

--- a/brainglobe_atlasapi/atlas_name.py
+++ b/brainglobe_atlasapi/atlas_name.py
@@ -227,6 +227,7 @@ AtlasName: TypeAlias = Literal[
     "sju_cavefish_2um",
     "swc_female_rat_50um",
     "unam_axolotl_40um",
+    "vfb_jrc2018u_neuropils_fly_0.5189161um",
     "whs_sd_rat_39um",
     "whs_sd_swc_female_rat_39um",
 ]

--- a/brainglobe_atlasapi/atlas_name.py
+++ b/brainglobe_atlasapi/atlas_name.py
@@ -227,7 +227,7 @@ AtlasName: TypeAlias = Literal[
     "sju_cavefish_2um",
     "swc_female_rat_50um",
     "unam_axolotl_40um",
-    "vfb_jrc2018u_neuropils_fly_0.5189161um",
+    "vfb_jrc2018u_neuropils_fly_0.519um",
     "whs_sd_rat_39um",
     "whs_sd_swc_female_rat_39um",
 ]


### PR DESCRIPTION
## Description

### What is this PR?

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

### Why is this PR needed?

This PR adds script for packaging the VFB ROI annotation on the JRC2018Unisex fly adult brain template into BrainGlobe format. 

### What does this PR do?

This PR adds `atlas_scripts/jrc2018u_neuropils_fly.py`.

## References

Relates to #471 .

Main atlas/template source:

- [https://www.virtualflybrain.org/blog/2022/01/01/jrc-2018-templates-rois-jrc2018/](https://www.virtualflybrain.org/blog/2022/01/01/jrc-2018-templates-rois-jrc2018/)

Main citation:

Bogovic JA, Otsuna H, Heinrich L, Ito M, Jeter J, et al. (2020) An unbiased template of the Drosophila brain and ventral nerve cord. PLOS ONE 15(12): e0236495. [https://doi.org/10.1371/journal.pone.0236495](https://doi.org/10.1371/journal.pone.0236495)

## How has this PR been tested?



## Is this a breaking change?

No. This PR only adds a new atlas generation script and should not change existing atlas behavior.

## Does this PR require an update to the documentation?

No documentation update has been added in this PR.


## Checklist

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with pre-commit

## Link to the .tar file

https://drive.google.com/file/d/1T0DniDHTzqChrmHZJbStn-zz2R03QRyu/view?usp=sharing

## Some images of the atlas in napari

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/1b3f6af3-bd7e-4aab-aca1-b74602c8781e" />

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/6d9e5c6c-f3a5-4c2f-8fed-25e63b4da06b" />


 


