### PR TITLE
Fixes docstring that throws error in sphinx autobuild

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -134,7 +134,9 @@ def check_internet_connection(
     timeout: int = 5,
     raise_error: bool = True,
 ) -> bool:
-    """Check that there is an internet connection
+    """
+    Check that there is an internet connection.
+
     url : str
         url to use for testing (Default value = 'http://www.google.com/')
     timeout : int


### PR DESCRIPTION
See https://github.com/brainglobe/brainglobe.github.io/issues/494 for context.

This fixes the docstring that lead to the error during sphinx autobuild by adding a new line after the """.