### PR TITLE
Fix tests for AtlasName validation, secondary reference wrapup

### DIFF
--- a/tests/atlasapi/test_list_atlases.py
+++ b/tests/atlasapi/test_list_atlases.py
@@ -94,7 +94,7 @@ def test_get_all_atlases_lastversions():
 
 
 def test_atlas_name_matches_lastversions():
-    """Ensure atlas name list matches last_versions.conf keys exactly."""
+    """Ensure all atlases in last_versions.conf are valid AtlasName values."""
     atlas_name_values = list(get_args(AtlasName))
     cache_path = (
         config.get_brainglobe_dir()
@@ -108,7 +108,7 @@ def test_atlas_name_matches_lastversions():
 
     assert len(atlas_name_values) == len(set(atlas_name_values))
     assert len(last_version_names) == len(set(last_version_names))
-    assert set(atlas_name_values) == set(last_version_names)
+    assert set(atlas_name_values).issuperset(set(last_version_names))
 
 
 def test_get_all_atlases_custom_atlases(mocker):

--- a/tests/atlasgen/test_wrapup.py
+++ b/tests/atlasgen/test_wrapup.py
@@ -406,7 +406,7 @@ def test_additional_reference_zarr_exists(wrapup_dir, atlas_version):
     """Test that the additional reference zarr is at the expected location."""
     assert (
         wrapup_dir
-        / f"templates/secondary-template/{atlas_version}"
+        / f"templates/{ATLAS_NAME}-secondary-template/{atlas_version}"
         / descriptors.V2_TEMPLATE_NAME
     ).exists()
 
@@ -453,7 +453,7 @@ def test_additional_reference_zarr_shape(wrapup_dir, atlas_version):
     """Additional reference zarr has the same spatial shape as the template."""
     ms = nz.from_ngff_zarr(
         wrapup_dir
-        / f"templates/secondary-template/{atlas_version}"
+        / f"templates/{ATLAS_NAME}-secondary-template/{atlas_version}"
         / descriptors.V2_TEMPLATE_NAME
     )
     data = ms.images[0].data.compute()
@@ -556,4 +556,7 @@ def test_atlas_manifest_additional_references(wrapup_dir, atlas_dir):
         manifest = json.load(f)
     assert "additional_references" in manifest
     assert len(manifest["additional_references"]) == 1
-    assert manifest["additional_references"][0]["name"] == "secondary-template"
+    assert (
+        manifest["additional_references"][0]["name"]
+        == f"{ATLAS_NAME}-secondary-template"
+    )


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
The tests fail if a new atlas is added to the AtlasName type without being available on the remote. This test will always fail while developing new atlases until the atlas is packaged and the `last_versions.conf` file is updated on the remote.

**What does this PR do?**
Relaxes the test conditions. Now, tests that all atlases from `last_versions.conf` are present in AtlasName without requiring strict equality. 

## How has this PR been tested?
Tested locally, all tests pass.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
