### PR TITLE
Add validation function for lowercase atlas names

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -77,6 +77,26 @@ def _save_if_not_exists(
     save_fn(stacks, dest_dir, transformations)
 
 
+def _validate_atlas_name(atlas_name: str) -> None:
+    """Validate that the atlas name is all lowercase.
+
+    Parameters
+    ----------
+    atlas_name : str
+        The name of the atlas to validate.
+
+    Raises
+    ------
+    ValueError
+        If the atlas name contains uppercase characters.
+    """
+    if atlas_name != atlas_name.lower():
+        raise ValueError(
+            f"Atlas name '{atlas_name}' must be lowercase. "
+            f"Got '{atlas_name}', expected '{atlas_name.lower()}'."
+        )
+
+
 def _merge_resolutions_list(
     existing_resolutions: ResolutionList,
     new_resolutions: ResolutionList,
@@ -809,6 +829,8 @@ def wrapup_atlas_from_data(
 
     if compress is not None:
         print("Warning: `compress` argument is deprecated and has no effect")
+
+    _validate_atlas_name(atlas_name)
 
     working_dir = Path(working_dir) / "brainglobe-atlasapi"
     atlas_version = f"{ATLAS_VERSION}.{atlas_minor_version}"

--- a/tests/test_validate_atlas_name.py
+++ b/tests/test_validate_atlas_name.py
@@ -1,0 +1,31 @@
+"""Unit tests for _validate_atlas_name in wrapup.py."""
+
+import pytest
+
+from brainglobe_atlasapi.atlas_generation.wrapup import _validate_atlas_name
+
+
+def test_validate_atlas_name_valid_lowercase():
+    """Lowercase atlas name passes validation without raising."""
+    try:
+        _validate_atlas_name("allen_mouse_25um")
+    except ValueError:
+        pytest.fail("Valid lowercase name raised ValueError unexpectedly")
+
+
+def test_validate_atlas_name_uppercase_raises():
+    """Uppercase characters in atlas name raise ValueError."""
+    with pytest.raises(ValueError, match="must be lowercase"):
+        _validate_atlas_name("Allen_Mouse_25um")
+
+
+def test_validate_atlas_name_mixed_case_raises():
+    """Mixed case atlas name raises ValueError."""
+    with pytest.raises(ValueError, match="must be lowercase"):
+        _validate_atlas_name("allen_Mouse_25um")
+
+
+def test_validate_atlas_name_all_caps_raises():
+    """All caps atlas name raises ValueError."""
+    with pytest.raises(ValueError, match="must be lowercase"):
+        _validate_atlas_name("ALLEN_MOUSE_25UM")


### PR DESCRIPTION
## Summary

Closes #831

Adds `_validate_atlas_name()` to `wrapup.py` that raises a `ValueError` 
if the atlas name contains uppercase characters. The function is called 
at the start of `wrapup_atlas_from_data()` before any processing begins.

## Changes

- Added `_validate_atlas_name(atlas_name: str)` in `wrapup.py`
- Called `_validate_atlas_name()` inside `wrapup_atlas_from_data()` 
  after deprecated argument checks
- Added `tests/test_validate_atlas_name.py` with 4 unit tests covering:
  - valid lowercase name passes without raising
  - uppercase name raises `ValueError`
  - mixed case name raises `ValueError`  
  - all caps name raises `ValueError`

## Notes

Tests are placed outside `tests/atlasgen/` to avoid the `autouse` 
fixture in `conftest.py` which has a pre-existing failure on `main` 
unrelated to this PR (`AttributeError: 'TransformSequence' object 
has no attribute 'scale'` in `core.py`).