### PR TITLE
Check HTTP status in retrieve_over_http before writing to disk

### DIFF
--- a/brainglobe_atlasapi/utils.py
+++ b/brainglobe_atlasapi/utils.py
@@ -258,6 +258,9 @@ def retrieve_over_http(
 
     try:
         response = requests.get(url, stream=True)
+        # Fail clearly on 4xx/5xx instead of saving an error page to disk,
+        # which would later surface as a misleading tarfile ReadError.
+        response.raise_for_status()
         with progress:
             tot = int(response.headers.get("content-length", 0))
 
@@ -286,6 +289,12 @@ def retrieve_over_http(
                         # update handler with completed and total bytes
                         fn_update(completed, tot)
 
+    except requests.exceptions.HTTPError as e:
+        output_file_path.unlink(missing_ok=True)
+        status = e.response.status_code if e.response is not None else "?"
+        raise requests.exceptions.HTTPError(
+            f"Failed to download file from {url}: HTTP {status}"
+        ) from e
     except requests.exceptions.ConnectionError:
         output_file_path.unlink(missing_ok=True)
         raise requests.exceptions.ConnectionError(

--- a/tests/atlasapi/test_utils.py
+++ b/tests/atlasapi/test_utils.py
@@ -395,6 +395,34 @@ def test_retrieve_over_http_ConnectionError(tmp_path):
             )
 
 
+def test_retrieve_over_http_HTTPError(tmp_path):
+    """A non-200 response should raise a clear HTTPError and not leave a file.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary path for test files.
+    """
+    output_file_path = tmp_path / "elephant"
+
+    mock_response = mock.Mock(spec=requests.Response)
+    mock_response.status_code = 403
+    http_error = requests.exceptions.HTTPError(response=mock_response)
+    mock_response.raise_for_status.side_effect = http_error
+
+    with mock.patch("requests.get", return_value=mock_response):
+        with pytest.raises(
+            requests.exceptions.HTTPError,
+            match="Failed to download file from elephants: HTTP 403",
+        ):
+            utils.retrieve_over_http(
+                url="elephants",
+                output_file_path=output_file_path,
+            )
+
+    assert not output_file_path.exists()
+
+
 @pytest.mark.parametrize(
     "content_length, expected_last_call",
     [pytest.param("6", (6, 6), id="6/6"), pytest.param(0, (6, 0), id="6/6")],


### PR DESCRIPTION
## Description

`utils.retrieve_over_http()` streamed `requests.get(url, ...)` straight to disk without ever checking the response status code. When the server returned a 403/404/503 (GIN IP blocking, transient outage, a wrong/missing version filename, etc.), the HTML/XML error body was written out *as if it were the atlas archive*. The failure then surfaced one step later in `download_extract_file()` as a confusing `ReadError: not a gzip file`, making a plain network/HTTP problem look like data corruption.

## Changes

- Add `response.raise_for_status()` immediately after `requests.get()`, so a 4xx/5xx fails before any error page is written to disk.
- Catch `requests.exceptions.HTTPError`, remove the partial file, and re-raise with a clear `Failed to download file from <url>: HTTP <status>` message.
- Add `test_retrieve_over_http_HTTPError` covering the 403 case (clear error raised, no partial file left behind).

This mirrors the status check that `conf_from_url()` already does for the config-download path.

Closes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)