### PR TITLE
Adds a lower pin for s3fs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pyarrow",
     "requests",
     "rich >= 9.0.0",
-    "s3fs",
+    "s3fs >= 2026",
     "tifffile>=2018.11.6",
     "treelib",
 ]


### PR DESCRIPTION
Dependency resolution was resorting to installing a very old version of `s3fs`.

Add a lower pin to make sure a modern version of `s3fs` is installed.