### PR TITLE
Add tqdm dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
     "rich >= 9.0.0",
     "s3fs >= 2026",
     "tifffile>=2018.11.6",
+    "tqdm",
     "treelib",
-    "tqdm"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "rich >= 9.0.0",
     "s3fs >= 2026",
     "tifffile>=2018.11.6",
-    "tqdm",
+    "tqdm >= 4.46.1",
     "treelib",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "s3fs >= 2026",
     "tifffile>=2018.11.6",
     "treelib",
+    "tqdm"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ atlasgen = [
     "ome-zarr<0.17.0",
     "PyMCubes",
     "SimpleITK",
-    "tqdm>=4.46.1",
     "vedo",
     "xmltodict",
     "pooch",


### PR DESCRIPTION
closes #868 

reproduced on two machines that this was crashing v3 installs in fresh environments. 