### PR TITLE
Refactor validation functions (part 1 of #782)

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -693,16 +693,18 @@ def validate_atlas(atlas_name, version, validation_functions):
         `error_message` is None if the check passes.
     """
     print(atlas_name, version)
+    # Triggers download so the atlas appears in get_atlases_lastversions()
     BrainGlobeAtlas(atlas_name)
     updated = get_atlases_lastversions()[atlas_name]["updated"]
     if not updated:
         update_atlas(atlas_name)
 
+    atlas = BrainGlobeAtlas(atlas_name)
     validation_results = {atlas_name: []}
 
-    for i, validation_function in enumerate(validation_functions):
+    for validation_function in validation_functions:
         try:
-            validation_function(BrainGlobeAtlas(atlas_name))
+            validation_function(atlas)
             validation_results[atlas_name].append(
                 (validation_function.__name__, None, str("Pass"))
             )

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -297,6 +297,39 @@ def validate_additional_references(atlas: BrainGlobeAtlas):
     return True
 
 
+def _get_structure_and_mesh_ids(atlas: BrainGlobeAtlas):
+    """Get structure IDs from the atlas and mesh IDs from the meshes folder.
+
+    Parameters
+    ----------
+    atlas : BrainGlobeAtlas
+        The BrainGlobeAtlas object to inspect.
+
+    Returns
+    -------
+    tuple of (list of int, list of int)
+        The structure IDs from `atlas.structures` and the mesh IDs found
+        in the atlas's `meshes` directory.
+    """
+    ids_from_bg_atlas_api = list(atlas.structures.keys())
+
+    atlas_path = atlas.root_dir
+    meshes_location = atlas.metadata["annotation_set"]["location"].lstrip("/")
+
+    mesh_path = (
+        Path(atlas_path) / meshes_location / descriptors.V3_MESHES_DIRECTORY
+    )
+
+    # Mesh files are named as <structure_id>
+    ids_from_mesh_files = [
+        int(f.stem)
+        for f in mesh_path.iterdir()
+        if (f.name != "info" and f.suffix != ".index")
+    ]
+
+    return ids_from_bg_atlas_api, ids_from_mesh_files
+
+
 def catch_missing_mesh_files(atlas: BrainGlobeAtlas):
     """Check if all structures in the atlas have a corresponding mesh file.
 
@@ -317,21 +350,9 @@ def catch_missing_mesh_files(atlas: BrainGlobeAtlas):
         If any structure ID found in `atlas.structures` does not have a
         matching mesh file in the atlas's `meshes` directory.
     """
-    ids_from_bg_atlas_api = list(atlas.structures.keys())
-
-    atlas_path = atlas.root_dir
-    meshes_location = atlas.metadata["annotation_set"]["location"].lstrip("/")
-
-    mesh_path = (
-        Path(atlas_path) / meshes_location / descriptors.V3_MESHES_DIRECTORY
+    ids_from_bg_atlas_api, ids_from_mesh_files = _get_structure_and_mesh_ids(
+        atlas
     )
-
-    # Mesh files are named as <structure_id>
-    ids_from_mesh_files = [
-        int(f.stem)
-        for f in mesh_path.iterdir()
-        if (f.name != "info" and f.suffix != ".index")
-    ]
 
     in_bg_not_mesh = []
     for mesh_id in ids_from_bg_atlas_api:
@@ -366,20 +387,9 @@ def catch_missing_structures(atlas: BrainGlobeAtlas):
         If any .obj file found in the atlas's 'meshes' directory does not
         have a corresponding structure ID in `atlas.structures`.
     """
-    ids_from_bg_atlas_api = list(atlas.structures.keys())
-
-    atlas_path = atlas.root_dir
-    meshes_location = atlas.metadata["annotation_set"]["location"].lstrip("/")
-
-    mesh_path = (
-        Path(atlas_path) / meshes_location / descriptors.V3_MESHES_DIRECTORY
+    ids_from_bg_atlas_api, ids_from_mesh_files = _get_structure_and_mesh_ids(
+        atlas
     )
-
-    ids_from_mesh_files = [
-        int(f.stem)
-        for f in mesh_path.iterdir()
-        if (f.name != "info" and f.suffix != ".index")
-    ]
 
     in_mesh_not_bg = []
     for id in ids_from_mesh_files:
@@ -711,6 +721,10 @@ def validate_atlas(atlas_name, version, validation_functions):
         except AssertionError as error:
             validation_results[atlas_name].append(
                 (validation_function.__name__, str(error), str("Fail"))
+            )
+        except Exception as error:
+            validation_results[atlas_name].append(
+                (validation_function.__name__, str(error), str("Error"))
             )
 
     return validation_results

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -19,7 +19,7 @@ from brainglobe_atlasapi.list_atlases import (
 from brainglobe_atlasapi.update_atlases import update_atlas
 
 
-def validate_atlas_files(atlas: BrainGlobeAtlas):
+def validate_atlas_files(atlas: BrainGlobeAtlas) -> bool:
     """
     Check if essential files exist in the atlas folder.
 
@@ -90,7 +90,9 @@ def validate_atlas_files(atlas: BrainGlobeAtlas):
     return True
 
 
-def _assert_close(mesh_coord, annotation_coord, pixel_size, diff_tolerance=10):
+def _assert_close(
+    mesh_coord, annotation_coord, pixel_size, diff_tolerance=10
+) -> bool:
     """
     Check if mesh and annotation coordinates are sufficiently close.
 
@@ -130,7 +132,7 @@ def _assert_close(mesh_coord, annotation_coord, pixel_size, diff_tolerance=10):
     return True
 
 
-def validate_mesh_matches_image_extents(atlas: BrainGlobeAtlas):
+def validate_mesh_matches_image_extents(atlas: BrainGlobeAtlas) -> bool:
     """Check if the mesh and the image extents are similar.
 
     Validates that the spatial extents of the `root` mesh align with the
@@ -193,7 +195,7 @@ def validate_mesh_matches_image_extents(atlas: BrainGlobeAtlas):
     return True
 
 
-def open_for_visual_check(atlas: BrainGlobeAtlas):
+def open_for_visual_check(atlas: BrainGlobeAtlas) -> bool:
     """Open the atlas for visual inspection (not implemented).
 
     This function is a placeholder for future visual validation routines.
@@ -212,7 +214,7 @@ def open_for_visual_check(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_checksum(atlas: BrainGlobeAtlas):
+def validate_checksum(atlas: BrainGlobeAtlas) -> bool:
     """Validate the atlas checksum (not implemented).
 
     This function is a placeholder for future checksum validation routines.
@@ -231,7 +233,7 @@ def validate_checksum(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_image_dimensions(atlas: BrainGlobeAtlas):
+def validate_image_dimensions(atlas: BrainGlobeAtlas) -> bool:
     """Check that annotation and template images have identical dimensions.
 
     Parameters
@@ -257,7 +259,7 @@ def validate_image_dimensions(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_additional_references(atlas: BrainGlobeAtlas):
+def validate_additional_references(atlas: BrainGlobeAtlas) -> bool:
     """Check that additional references have expected properties.
 
     Verifies that all additional reference images:
@@ -297,7 +299,9 @@ def validate_additional_references(atlas: BrainGlobeAtlas):
     return True
 
 
-def _get_structure_and_mesh_ids(atlas: BrainGlobeAtlas):
+def _get_structure_and_mesh_ids(
+    atlas: BrainGlobeAtlas,
+) -> tuple[list[int], list[int]]:
     """Get structure IDs from the atlas and mesh IDs from the meshes folder.
 
     Parameters
@@ -330,7 +334,7 @@ def _get_structure_and_mesh_ids(atlas: BrainGlobeAtlas):
     return ids_from_bg_atlas_api, ids_from_mesh_files
 
 
-def catch_missing_mesh_files(atlas: BrainGlobeAtlas):
+def catch_missing_mesh_files(atlas: BrainGlobeAtlas) -> bool:
     """Check if all structures in the atlas have a corresponding mesh file.
 
     Parameters
@@ -367,7 +371,7 @@ def catch_missing_mesh_files(atlas: BrainGlobeAtlas):
     return True
 
 
-def catch_missing_structures(atlas: BrainGlobeAtlas):
+def catch_missing_structures(atlas: BrainGlobeAtlas) -> bool:
     """Check if all mesh files in the atlas folder are listed as a structure.
 
     Parameters
@@ -404,7 +408,7 @@ def catch_missing_structures(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_template_image_pixels(atlas: BrainGlobeAtlas):
+def validate_template_image_pixels(atlas: BrainGlobeAtlas) -> bool:
     """Validate that the template image was correctly rescaled.
 
     This check aims to catch issues where a float64 template image (e.g., from
@@ -436,7 +440,7 @@ def validate_template_image_pixels(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
+def validate_annotation_symmetry(atlas: BrainGlobeAtlas) -> bool:
     """Validate that equivalent regions in left and right hemispheres have the
     same annotation value.
 
@@ -476,7 +480,7 @@ def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_unique_acronyms(atlas: BrainGlobeAtlas):
+def validate_unique_acronyms(atlas: BrainGlobeAtlas) -> bool:
     """Validate that all structure acronyms in the atlas are unique.
 
     Duplicate acronyms are incompatible with the current implementation
@@ -515,7 +519,7 @@ def validate_unique_acronyms(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_atlas_name(atlas: BrainGlobeAtlas):
+def validate_atlas_name(atlas: BrainGlobeAtlas) -> bool:
     """Validate the naming convention of the atlas.
 
     Checks if the atlas name adheres to specific rules:
@@ -559,7 +563,7 @@ def validate_atlas_name(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_atlas_name_listed(atlas: BrainGlobeAtlas):
+def validate_atlas_name_listed(atlas: BrainGlobeAtlas) -> bool:
     """Validate that the atlas name is listed in atlas_name.py.
 
     Parameters
@@ -584,7 +588,7 @@ def validate_atlas_name_listed(atlas: BrainGlobeAtlas):
     return True
 
 
-def validate_metadata(atlas: BrainGlobeAtlas):
+def validate_metadata(atlas: BrainGlobeAtlas) -> bool:
     """Validate the atlas metadata.
 
     Checks that the metadata of the given atlas has the correct format.


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other (refactor)

**Why is this PR needed?**

First of three PRs for #782. The validation functions need updating for the v2 atlas format, but there's some pre-existing duplication and inefficiency in `validate_atlases.py` that's easier to clear out first. Splitting it this way keeps the format-migration diffs small and reviewable.

This PR is a **pure refactor with no behaviour changes**. No validation logic is altered, and the xfail markers in `tests/atlasgen/test_validation.py` are untouched.

**What does this PR do?**

- `validate_atlas` constructed a new `BrainGlobeAtlas` for every validation function in the loop. It now constructs one instance after `update_atlas` and reuses it. The separate bare `BrainGlobeAtlas(atlas_name)` call above is deliberately kept, since it triggers the download so the atlas appears in `get_atlases_lastversions()`, and I've added a comment saying so.
- Extracted the duplicated structure-ID/mesh-ID lookup shared by `catch_missing_mesh_files` and `catch_missing_structures` into `_get_structure_and_mesh_ids`. Both functions keep their own comparison direction and assertion messages.
- `validate_atlas` caught only `AssertionError`, so a `ValueError` from `int(f.stem)` or an S3/OS error would abort the entire run and lose all results collected so far. Non-assertion exceptions are now recorded with a distinct `"Error"` status, keeping "atlas is invalid" distinguishable from "the check itself failed".

One thing I looked at and deliberately left alone: `report_validation_results` expects a flat `{func_name: "Pass"/"Fail: msg"}` dict, while `validate_atlas` returns `{atlas_name: [(func_name, error, status)]}`. These are incompatible, but `wrapup.py` is the only caller and it builds the flat shape itself, so there's no live bug. The underlying issue is that there are two independent implementations of "run all validators and collect results". I've raised that as a question on #782 rather than changing it here.

## References

Part 1 of 3 for #782. Follows on from #769.

## How has this PR been tested?

Full test suite run locally before and after: 332 passed, 5 xfailed, unchanged. The 5 xfails are the validation tests awaiting the v2 format work in the later PRs.

No behaviour was intentionally changed, so no test changes were needed. I reviewed each diff hunk to confirm the extracted logic and the assertion messages are identical to before.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No. There are no public API or behaviour changes, and `_get_structure_and_mesh_ids` is private.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration). Not applicable, no new functionality.
- [ ] The documentation has been updated to reflect any changes. Not applicable.
- [x] The code has been formatted with [[pre-commit](https://pre-commit.com/)](https://pre-commit.com/)
