### PR TITLE
Adds a tranlsation transform to account for downsampling

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -143,13 +143,23 @@ def _transformations_from_scales(
         Scale (voxel size) per axis for each pyramid level, ordered from
         highest to lowest resolution.
     """
-    base = scales[0]
-    assert all(
-        scale >= reference
-        for level in scales
-        for scale, reference in zip(level, base)
-    ), f"Scales must be ordered from highest to lowest resolution: {scales}"
+    scales = [list(level) for level in scales]
+    if not scales:
+        raise ValueError("scales must be a non-empty sequence of per-level scales")
 
+    ndim = len(scales[0])
+    if any(len(level) != ndim for level in scales):
+        raise ValueError(f"All scale levels must have {ndim} axes: {scales}")
+
+    if any(
+        any(curr < prev for curr, prev in zip(scales[i], scales[i - 1]))
+        for i in range(1, len(scales))
+    ):
+        raise ValueError(
+            f"Scales must be ordered from highest to lowest resolution: {scales}"
+        )
+
+    base = scales[0]
     return [
         [
             {"type": "scale", "scale": list(level)},

--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -145,7 +145,9 @@ def _transformations_from_scales(
     """
     scales = [list(level) for level in scales]
     if not scales:
-        raise ValueError("scales must be a non-empty sequence of per-level scales")
+        raise ValueError(
+            "scales must be a non-empty sequence of per-level scales"
+        )
 
     ndim = len(scales[0])
     if any(len(level) != ndim for level in scales):

--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -165,17 +165,6 @@ def _transformations_from_scales(
     ]
 
 
-def _build_transformations(
-    resolution_standard: ResolutionList,
-) -> List[List[dict]]:
-    return _transformations_from_scales(
-        [
-            [res / 1000 for res in res_tuple]
-            for res_tuple in resolution_standard
-        ]
-    )
-
-
 def _save_terminology_csv(
     structures_list: List[Dict],
     terminology_path: Path,
@@ -1070,7 +1059,9 @@ def wrapup_atlas_from_data(
         additional_metadata=additional_metadata,
     )
 
-    transformations = _build_transformations(packaging_data.resolution)
+    transformations = _transformations_from_scales(
+        [[res / 1000 for res in t] for t in packaging_data.resolution]
+    )
 
     template_multiscale = _save_template_data(
         packaging_data,

--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -158,7 +158,7 @@ def _transformations_from_scales(
         for i in range(1, len(scales))
     ):
         raise ValueError(
-            f"Scales must be ordered from highest to lowest resolution: {scales}"
+            f"Resolutions must be ordered from highest to lowest: {scales}"
         )
 
     base = scales[0]

--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -3,7 +3,7 @@
 import json
 import shutil
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import brainglobe_space as bgs
 import dask.array as da
@@ -122,10 +122,7 @@ def _insert_into_multiscale(
     stack_list = [
         resolution_to_data[res].astype(dtype) for res in merged_resolutions
     ]
-    new_transformations = [
-        [{"type": "scale", "scale": list(res_tuple)}]
-        for res_tuple in merged_resolutions
-    ]
+    new_transformations = _transformations_from_scales(merged_resolutions)
 
     write_multiscale_ome_zarr(
         images=stack_list,
@@ -135,13 +132,48 @@ def _insert_into_multiscale(
     )
 
 
+def _transformations_from_scales(
+    scales: Sequence[Sequence[float]],
+) -> List[List[dict]]:
+    """Build OME-Zarr coordinate transformations from per-level scales.
+
+    Parameters
+    ----------
+    scales : sequence of sequences of float
+        Scale (voxel size) per axis for each pyramid level, ordered from
+        highest to lowest resolution.
+    """
+    base = scales[0]
+    assert all(
+        scale >= reference
+        for level in scales
+        for scale, reference in zip(level, base)
+    ), f"Scales must be ordered from highest to lowest resolution: {scales}"
+
+    return [
+        [
+            {"type": "scale", "scale": list(level)},
+            {
+                "type": "translation",
+                "translation": [
+                    round((scale - reference) / 2, 9)
+                    for scale, reference in zip(level, base)
+                ],
+            },
+        ]
+        for level in scales
+    ]
+
+
 def _build_transformations(
     resolution_standard: ResolutionList,
 ) -> List[List[dict]]:
-    return [
-        [{"type": "scale", "scale": [res / 1000 for res in res_tuple]}]
-        for res_tuple in resolution_standard
-    ]
+    return _transformations_from_scales(
+        [
+            [res / 1000 for res in res_tuple]
+            for res_tuple in resolution_standard
+        ]
+    )
 
 
 def _save_terminology_csv(
@@ -544,10 +576,9 @@ def _save_4d_annotation_data(
     structures_tree = get_structures_tree(packaging_data.structures_list)
     mapping = _generate_annotation_mapping(structures_tree)
 
-    transformations_4d = [
-        [{"type": "scale", "scale": [1.0] + t[0]["scale"]}]
-        for t in transformations
-    ]
+    transformations_4d = _transformations_from_scales(
+        [[1.0] + t[0]["scale"] for t in transformations]
+    )
 
     masks_path = dest_dir / descriptors.V3_ANNOTATION_MASKS_NAME
     scratch_dir = dest_dir / ".mask_scratch"
@@ -648,10 +679,9 @@ def _insert_into_4d_masks(
         )
 
         merged_stack = [resolution_to_data[res] for res in merged_resolutions]
-        transformations_4d = [
-            [{"type": "scale", "scale": [1.0] + list(res)}]
-            for res in merged_resolutions
-        ]
+        transformations_4d = _transformations_from_scales(
+            [[1.0] + list(res) for res in merged_resolutions]
+        )
 
         save_annotation_masks(merged_stack, target_dir, transformations_4d)
 

--- a/tests/atlasgen/test_wrapup.py
+++ b/tests/atlasgen/test_wrapup.py
@@ -25,7 +25,6 @@ from brainglobe_atlasapi.atlas_generation.stacks import (
     write_multiscale_ome_zarr,
 )
 from brainglobe_atlasapi.atlas_generation.wrapup import (
-    _build_transformations,
     _compute_4d_masks_for_scale,
     _generate_annotation_mapping,
     _insert_into_4d_masks,
@@ -35,6 +34,7 @@ from brainglobe_atlasapi.atlas_generation.wrapup import (
     _save_coordinate_space_manifest,
     _save_if_not_exists,
     _save_terminology_csv,
+    _transformations_from_scales,
     wrapup_atlas_from_data,
 )
 from brainglobe_atlasapi.structure_tree_util import get_structures_tree
@@ -110,38 +110,24 @@ def test_insert_into_multiscale_merges_two_scale_levels(tmp_path):
     assert len(result.images) == 2
 
 
-# --- _build_transformations ---
+# --- _transformations_from_scales ---
 
 
-def test_build_transformations_divides_by_1000():
-    """Test that resolution in microns is converted to mm (divide by 1000)."""
-    result = _build_transformations([(10, 10, 10)])
-    assert result == [
-        [
-            {"type": "scale", "scale": [0.01, 0.01, 0.01]},
-            {"type": "translation", "translation": [0.0, 0.0, 0.0]},
-        ]
+def test_transformations_from_scales_per_axis():
+    """Scales are written per axis, one transformation per level."""
+    result = _transformations_from_scales(
+        [[0.01, 0.02, 0.03], [0.02, 0.04, 0.06]]
+    )
+    assert [t[0] for t in result] == [
+        {"type": "scale", "scale": [0.01, 0.02, 0.03]},
+        {"type": "scale", "scale": [0.02, 0.04, 0.06]},
     ]
 
 
-def test_build_transformations_multiple_resolutions():
-    """Test that multiple resolutions produce multiple transformations."""
-    result = _build_transformations([(10, 10, 10), (20, 20, 20)])
-    assert len(result) == 2
-    assert result[0][0] == {"type": "scale", "scale": [0.01, 0.01, 0.01]}
-    assert result[1][0] == {"type": "scale", "scale": [0.02, 0.02, 0.02]}
-
-
-def test_build_transformations_anisotropic():
-    """Test that anisotropic resolutions are handled per-axis."""
-    result = _build_transformations([(10, 20, 30)])
-    assert result[0][0] == {"type": "scale", "scale": [0.01, 0.02, 0.03]}
-
-
-def test_build_transformations_offsets_downsampled_levels():
+def test_transformations_from_scales_offsets_downsampled_levels():
     """Coarse levels are offset by half the voxel size difference."""
-    result = _build_transformations(
-        [(10, 10, 10), (25, 25, 25), (100, 100, 100)]
+    result = _transformations_from_scales(
+        [[0.01, 0.01, 0.01], [0.025, 0.025, 0.025], [0.1, 0.1, 0.1]]
     )
     translations = [t[1]["translation"] for t in result]
     assert translations == [
@@ -151,10 +137,10 @@ def test_build_transformations_offsets_downsampled_levels():
     ]
 
 
-def test_build_transformations_rejects_coarsest_first():
+def test_transformations_from_scales_rejects_coarsest_first():
     """A pyramid ordered coarsest-first fails loudly, not silently."""
     with pytest.raises(AssertionError, match="highest to lowest resolution"):
-        _build_transformations([(20, 20, 20), (10, 10, 10)])
+        _transformations_from_scales([[0.02, 0.02, 0.02], [0.01, 0.01, 0.01]])
 
 
 # --- _generate_annotation_mapping ---

--- a/tests/atlasgen/test_wrapup.py
+++ b/tests/atlasgen/test_wrapup.py
@@ -116,21 +116,45 @@ def test_insert_into_multiscale_merges_two_scale_levels(tmp_path):
 def test_build_transformations_divides_by_1000():
     """Test that resolution in microns is converted to mm (divide by 1000)."""
     result = _build_transformations([(10, 10, 10)])
-    assert result == [[{"type": "scale", "scale": [0.01, 0.01, 0.01]}]]
+    assert result == [
+        [
+            {"type": "scale", "scale": [0.01, 0.01, 0.01]},
+            {"type": "translation", "translation": [0.0, 0.0, 0.0]},
+        ]
+    ]
 
 
 def test_build_transformations_multiple_resolutions():
     """Test that multiple resolutions produce multiple transformations."""
     result = _build_transformations([(10, 10, 10), (20, 20, 20)])
     assert len(result) == 2
-    assert result[0] == [{"type": "scale", "scale": [0.01, 0.01, 0.01]}]
-    assert result[1] == [{"type": "scale", "scale": [0.02, 0.02, 0.02]}]
+    assert result[0][0] == {"type": "scale", "scale": [0.01, 0.01, 0.01]}
+    assert result[1][0] == {"type": "scale", "scale": [0.02, 0.02, 0.02]}
 
 
 def test_build_transformations_anisotropic():
     """Test that anisotropic resolutions are handled per-axis."""
     result = _build_transformations([(10, 20, 30)])
-    assert result == [[{"type": "scale", "scale": [0.01, 0.02, 0.03]}]]
+    assert result[0][0] == {"type": "scale", "scale": [0.01, 0.02, 0.03]}
+
+
+def test_build_transformations_offsets_downsampled_levels():
+    """Coarse levels are offset by half the voxel size difference."""
+    result = _build_transformations(
+        [(10, 10, 10), (25, 25, 25), (100, 100, 100)]
+    )
+    translations = [t[1]["translation"] for t in result]
+    assert translations == [
+        [0.0, 0.0, 0.0],
+        [0.0075, 0.0075, 0.0075],
+        [0.045, 0.045, 0.045],
+    ]
+
+
+def test_build_transformations_rejects_coarsest_first():
+    """A pyramid ordered coarsest-first fails loudly, not silently."""
+    with pytest.raises(AssertionError, match="highest to lowest resolution"):
+        _build_transformations([(20, 20, 20), (10, 10, 10)])
 
 
 # --- _generate_annotation_mapping ---

--- a/tests/atlasgen/test_wrapup.py
+++ b/tests/atlasgen/test_wrapup.py
@@ -139,7 +139,7 @@ def test_transformations_from_scales_offsets_downsampled_levels():
 
 def test_transformations_from_scales_rejects_coarsest_first():
     """A pyramid ordered coarsest-first fails loudly, not silently."""
-    with pytest.raises(ValueError, match="highest to lowest"): 
+    with pytest.raises(ValueError, match="highest to lowest"):
         _transformations_from_scales([[0.02, 0.02, 0.02], [0.01, 0.01, 0.01]])
 
 

--- a/tests/atlasgen/test_wrapup.py
+++ b/tests/atlasgen/test_wrapup.py
@@ -139,7 +139,7 @@ def test_transformations_from_scales_offsets_downsampled_levels():
 
 def test_transformations_from_scales_rejects_coarsest_first():
     """A pyramid ordered coarsest-first fails loudly, not silently."""
-    with pytest.raises(AssertionError, match="highest to lowest resolution"):
+    with pytest.raises(ValueError, match="highest to lowest resolution"):
         _transformations_from_scales([[0.02, 0.02, 0.02], [0.01, 0.01, 0.01]])
 
 

--- a/tests/atlasgen/test_wrapup.py
+++ b/tests/atlasgen/test_wrapup.py
@@ -139,7 +139,7 @@ def test_transformations_from_scales_offsets_downsampled_levels():
 
 def test_transformations_from_scales_rejects_coarsest_first():
     """A pyramid ordered coarsest-first fails loudly, not silently."""
-    with pytest.raises(ValueError, match="highest to lowest resolution"):
+    with pytest.raises(ValueError, match="highest to lowest"): 
         _transformations_from_scales([[0.02, 0.02, 0.02], [0.01, 0.01, 0.01]])
 
 


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See #884 

**What does this PR do?**
Adds an extra transform that shifts the downsampled pyramids of constructed atlases to account for downsampling.

## References
Closes #884 

## How has this PR been tested?
New tests added to ensure the correct transforms are written.

Existing components in `s3://brainglobe/atlas-rc2` have been updated.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
