### PR TITLE
change blosccodec to use bit shuffle as string

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/mesh_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/mesh_utils.py
@@ -358,7 +358,9 @@ def construct_meshes_from_annotation(
     volume_size = volume.size
     if parallel:
         compressor = zarr.codecs.BloscCodec(
-            cname="zstd", clevel=6, shuffle=zarr.codecs.BloscShuffle.bitshuffle
+            cname="zstd",
+            clevel=6,
+            shuffle="bitshuffle",
         )
 
         if ann_path.exists():


### PR DESCRIPTION
closes #894 

[Tests were failing ](https://github.com/brainglobe/brainglobe-atlasapi/actions/runs/30625244867/job/91138918189?pr=892) because [zarr deprecated ](https://zarr.readthedocs.io/en/latest/release-notes/)the way we were passing bitshuffle to the compressor. This updates the call to the new method