### PR TITLE
Fix centre calculation for atlas validation

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -451,14 +451,18 @@ def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
         If the annotation labels at the chosen symmetric points are different.
     """
     annotation = atlas.annotation
-    centre = np.min(np.array(annotation.shape) / 2).astype(int)
+    
+    annotation_shape = np.array(annotation.shape) 
+    remainder = 1 - (annotation_shape[2] % 2)
+    centre = annotation_shape // 2
     central_leftright_axis_annotations = annotation[centre[0], centre[1], :]
-    label_5_left_of_centre = central_leftright_axis_annotations[centre[2] + 5]
+    label_5_left_of_centre = central_leftright_axis_annotations[centre[2] + (5 - remainder)]
     label_5_right_of_centre = central_leftright_axis_annotations[centre[2] - 5]
     assert (
         label_5_left_of_centre == label_5_right_of_centre
     ), "Annotation labels are asymmetric."
     return True
+
 
 
 def validate_unique_acronyms(atlas: BrainGlobeAtlas):

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -451,18 +451,19 @@ def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
         If the annotation labels at the chosen symmetric points are different.
     """
     annotation = atlas.annotation
-    
-    annotation_shape = np.array(annotation.shape) 
+
+    annotation_shape = np.array(annotation.shape)
     remainder = 1 - (annotation_shape[2] % 2)
     centre = annotation_shape // 2
     central_leftright_axis_annotations = annotation[centre[0], centre[1], :]
-    label_5_left_of_centre = central_leftright_axis_annotations[centre[2] + (5 - remainder)]
+    label_5_left_of_centre = central_leftright_axis_annotations[
+        centre[2] + (5 - remainder)
+    ]
     label_5_right_of_centre = central_leftright_axis_annotations[centre[2] - 5]
     assert (
         label_5_left_of_centre == label_5_right_of_centre
     ), "Annotation labels are asymmetric."
     return True
-
 
 
 def validate_unique_acronyms(atlas: BrainGlobeAtlas):

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -451,7 +451,7 @@ def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
         If the annotation labels at the chosen symmetric points are different.
     """
     annotation = atlas.annotation
-    centre = np.array(annotation.shape) // 2
+    centre = np.min(np.array(annotation.shape) / 2).astype(int)
     central_leftright_axis_annotations = annotation[centre[0], centre[1], :]
     label_5_left_of_centre = central_leftright_axis_annotations[centre[2] + 5]
     label_5_right_of_centre = central_leftright_axis_annotations[centre[2] - 5]

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -453,11 +453,11 @@ def validate_annotation_symmetry(atlas: BrainGlobeAtlas):
     annotation = atlas.annotation
 
     annotation_shape = np.array(annotation.shape)
-    remainder = 1 - (annotation_shape[2] % 2)
+    remainder = annotation_shape[2] % 2
     centre = annotation_shape // 2
     central_leftright_axis_annotations = annotation[centre[0], centre[1], :]
     label_5_left_of_centre = central_leftright_axis_annotations[
-        centre[2] + (5 - remainder)
+        centre[2] + (4 + remainder)
     ]
     label_5_right_of_centre = central_leftright_axis_annotations[centre[2] - 5]
     assert (

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -394,6 +394,29 @@ def test_asymmetrical_annotation_fails(mocker, atlas):
         validate_annotation_symmetry(atlas)
 
 
+@pytest.mark.parametrize("width", ["odd", "even"])
+def test_odd_and_even_pass_atlas_symmetry(mocker, atlas, width):
+    """Ensure odd- and even-width atlases pass symmetry validation."""
+    # create a mirror image atlas of ascending and descending values
+    hemisphere = np.zeros((50, 50, 50))
+    hemisphere[:, :, :] = np.arange(50)
+    annotation = np.concatenate(
+        (hemisphere, hemisphere[:, :, ::-1]),
+        axis=2,
+    )
+
+    if width == "odd":
+        annotation = np.insert(annotation, 50, 0, axis=2)
+
+    mocker.patch(
+        "brainglobe_atlasapi.BrainGlobeAtlas.annotation",
+        new_callable=mocker.PropertyMock,
+        return_value=annotation,
+    )
+
+    validate_annotation_symmetry(atlas)
+
+
 @pytest.mark.parametrize(
     "atlas_name, should_pass, error_message",
     [


### PR DESCRIPTION
Change calculation of centre to work with both even and odd width volumes.
closes #893 


## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Atlas symmetry check fails for volumes with an even width. 

## How has this PR been tested?

I packaged the Allen human atlas which was previously failing validation. It now passes.
This has also been tested on several other even width atlases as well as one odd width (australian mouse).

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
