### PR TITLE
add optional license information to atlases

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
@@ -382,8 +382,11 @@ class AtlasPackagingData:
     atlas_packager : str, optional
         Credit for those responsible for converting the atlas into the
         BrainGlobe format.
-    license : Dict[str, str], optional
-        License metadata with ``license`` and ``link_to_license`` fields.
+    license : Dict[str, str | None] or None, optional
+        License metadata with ``license`` and ``link_to_license`` fields. The
+        ``link_to_license`` value may be ``None`` for an explicitly unlicensed
+        atlas. The entire field may also be ``None`` when license metadata is
+        not provided.
     hemispheres_stack : ValidComponentData, optional
         Hemisphere stack for the atlas. If None, atlas is assumed symmetric.
     additional_references : List[Tuple[TemplateInfo, ValidComponentData]], optional
@@ -415,7 +418,7 @@ class AtlasPackagingData:
     space_convention: bgs.AnatomicalSpace | None = None
     atlas_version_underscore: Optional[str] = None
     atlas_packager: str | None = None
-    license: Dict[str, str] | None = None
+    license: Dict[str, str | None] | None = None
     hemispheres_stack: ValidComponentData = None
     additional_references: List[
         Tuple[

--- a/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
@@ -382,6 +382,8 @@ class AtlasPackagingData:
     atlas_packager : str, optional
         Credit for those responsible for converting the atlas into the
         BrainGlobe format.
+    license : Dict[str, str], optional
+        License metadata with ``license`` and ``link_to_license`` fields.
     hemispheres_stack : ValidComponentData, optional
         Hemisphere stack for the atlas. If None, atlas is assumed symmetric.
     additional_references : List[Tuple[TemplateInfo, ValidComponentData]], optional
@@ -413,6 +415,7 @@ class AtlasPackagingData:
     space_convention: bgs.AnatomicalSpace | None = None
     atlas_version_underscore: Optional[str] = None
     atlas_packager: str | None = None
+    license: Dict[str, str] | None = None
     hemispheres_stack: ValidComponentData = None
     additional_references: List[
         Tuple[

--- a/brainglobe_atlasapi/atlas_generation/metadata_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/metadata_utils.py
@@ -41,7 +41,7 @@ def generate_metadata_dict(
     terminology: TerminologyInfo,
     annotation_set: AnnotationInfo,
     template: TemplateInfo,
-    license: Dict[str, str] | None = None,
+    license: Dict[str, str | None] | None = None,
 ):
     """
     Generate a dictionary containing metadata for a BrainGlobe atlas.
@@ -80,8 +80,11 @@ def generate_metadata_dict(
         Metadata for the annotation set.
     template : TemplateInfo
         Metadata for the template.
-    license : Dict[str, str | None], optional
-        License metadata with ``license`` and ``link_to_license`` fields.
+    license : Dict[str, str | None] or None, optional
+        License metadata with ``license`` and ``link_to_license`` fields. The
+        ``link_to_license`` value may be ``None`` for an explicitly unlicensed
+        atlas. The entire field may also be ``None`` when license metadata is
+        not provided.
 
 
     Returns
@@ -136,12 +139,12 @@ def generate_metadata_dict(
                 f"{', '.join(sorted(unexpected_fields))}"
             )
 
-        if any(
-            not isinstance(license[field], str)
-            for field in required_license_fields
+        if not isinstance(license["license"], str) or not isinstance(
+            license["link_to_license"], (str, type(None))
         ):
             raise TypeError(
-                "license and link_to_license values must be strings"
+                "license must be a string and link_to_license must be a "
+                "string or None"
             )
 
     additional_references_metadata = [

--- a/brainglobe_atlasapi/atlas_generation/metadata_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/metadata_utils.py
@@ -139,13 +139,11 @@ def generate_metadata_dict(
                 f"{', '.join(sorted(unexpected_fields))}"
             )
 
-        if not isinstance(license["license"], str) or not isinstance(
-            license["link_to_license"], (str, type(None))
-        ):
-            raise TypeError(
-                "license must be a string and link_to_license must be a "
-                "string or None"
-            )
+        if not isinstance(license["license"], str):
+            raise TypeError("license must be a string")
+
+        if not isinstance(license["link_to_license"], (str, type(None))):
+            raise TypeError("link_to_license must be a string or None")
 
     additional_references_metadata = [
         ref_info.metadata for ref_info in additional_references

--- a/brainglobe_atlasapi/atlas_generation/metadata_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/metadata_utils.py
@@ -117,6 +117,33 @@ def generate_metadata_dict(
 
     assert isinstance(additional_references, list)
 
+    if license is not None:
+        if not isinstance(license, dict):
+            raise TypeError("license must be a dictionary or None")
+
+        required_license_fields = {"license", "link_to_license"}
+        missing_fields = required_license_fields - license.keys()
+        if missing_fields:
+            raise ValueError(
+                "license is missing required fields: "
+                f"{', '.join(sorted(missing_fields))}"
+            )
+
+        unexpected_fields = license.keys() - required_license_fields
+        if unexpected_fields:
+            raise ValueError(
+                "license contains unexpected fields: "
+                f"{', '.join(sorted(unexpected_fields))}"
+            )
+
+        if any(
+            not isinstance(license[field], str)
+            for field in required_license_fields
+        ):
+            raise TypeError(
+                "license and link_to_license values must be strings"
+            )
+
     additional_references_metadata = [
         ref_info.metadata for ref_info in additional_references
     ]

--- a/brainglobe_atlasapi/atlas_generation/metadata_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/metadata_utils.py
@@ -6,7 +6,7 @@ README files associated with atlases packaged within the BrainGlobe ecosystem.
 import json
 import re
 from datetime import datetime
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import requests
 from requests.exceptions import InvalidURL, MissingSchema
@@ -41,6 +41,7 @@ def generate_metadata_dict(
     terminology: TerminologyInfo,
     annotation_set: AnnotationInfo,
     template: TemplateInfo,
+    license: Dict[str, str] | None = None,
 ):
     """
     Generate a dictionary containing metadata for a BrainGlobe atlas.
@@ -79,6 +80,8 @@ def generate_metadata_dict(
         Metadata for the annotation set.
     template : TemplateInfo
         Metadata for the template.
+    license : Dict[str, str], optional
+        License metadata with ``license`` and ``link_to_license`` fields.
 
 
     Returns
@@ -131,6 +134,7 @@ def generate_metadata_dict(
         shape=shape,
         additional_references=additional_references_metadata,
         atlas_packager=atlas_packager,
+        license=license,
         coordinate_space=coordinate_space.metadata,
         terminology=terminology.metadata,
         annotation_set=annotation_set.metadata,

--- a/brainglobe_atlasapi/atlas_generation/metadata_utils.py
+++ b/brainglobe_atlasapi/atlas_generation/metadata_utils.py
@@ -80,7 +80,7 @@ def generate_metadata_dict(
         Metadata for the annotation set.
     template : TemplateInfo
         Metadata for the template.
-    license : Dict[str, str], optional
+    license : Dict[str, str | None], optional
         License metadata with ``license`` and ``link_to_license`` fields.
 
 

--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -852,7 +852,7 @@ def wrapup_atlas_from_data(
     overwrite=False,
     cleanup_files=None,
     compress=None,
-    license: Dict[str, str] | None = None,
+    license: Dict[str, str | None] | None = None,
 ) -> Path:
     """
     Finalise an atlas with truly consistent format from all the data.
@@ -926,9 +926,11 @@ def wrapup_atlas_from_data(
     compress : deprecated, optional
         (Default value = None).
         Deprecated and has no effect.
-    license : dict, optional
+    license : Dict[str, str | None] or None, optional
         License metadata in the form ``{"license": license_short_name,
-        "link_to_license": url}``. Defaults to ``None``.
+        "link_to_license": url_or_none}``. ``link_to_license`` may be
+        ``None`` for an explicitly unlicensed atlas. The entire field defaults
+        to ``None`` when license metadata is not provided.
 
     Returns
     -------

--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -831,7 +831,6 @@ def wrapup_atlas_from_data(
     meshes_dict: Dict[int | str, str | Path],
     working_dir: str | Path,
     atlas_packager=None,
-    license: Dict[str, str] | None = None,
     hemispheres_stack=None,
     template_info: Dict[str, str | bool] | None = None,
     annotation_info: Dict[str, str | bool] | None = None,
@@ -853,6 +852,7 @@ def wrapup_atlas_from_data(
     overwrite=False,
     cleanup_files=None,
     compress=None,
+    license: Dict[str, str] | None = None,
 ) -> Path:
     """
     Finalise an atlas with truly consistent format from all the data.
@@ -897,9 +897,6 @@ def wrapup_atlas_from_data(
     atlas_packager : str or None
         Credit for those responsible for converting the atlas
         into the BrainGlobe format.
-    license : dict, optional
-        License metadata in the form ``{"license": license_short_name,
-        "link_to_license": url}``. Defaults to ``None``.
     hemispheres_stack : ValidComponentData | None, optional
         Hemisphere stack for the atlas.
         If str or Path, will be read with tifffile.
@@ -929,6 +926,9 @@ def wrapup_atlas_from_data(
     compress : deprecated, optional
         (Default value = None).
         Deprecated and has no effect.
+    license : dict, optional
+        License metadata in the form ``{"license": license_short_name,
+        "link_to_license": url}``. Defaults to ``None``.
 
     Returns
     -------

--- a/brainglobe_atlasapi/atlas_generation/wrapup.py
+++ b/brainglobe_atlasapi/atlas_generation/wrapup.py
@@ -780,6 +780,7 @@ def _finalize_atlas_at_resolution(
         shape=shape,
         additional_references=additional_references,
         atlas_packager=packaging_data.atlas_packager,
+        license=packaging_data.license,
         coordinate_space=packaging_data.coordinate_space_info,
         terminology=packaging_data.terminology_info,
         annotation_set=packaging_data.annotation_info,
@@ -830,6 +831,7 @@ def wrapup_atlas_from_data(
     meshes_dict: Dict[int | str, str | Path],
     working_dir: str | Path,
     atlas_packager=None,
+    license: Dict[str, str] | None = None,
     hemispheres_stack=None,
     template_info: Dict[str, str | bool] | None = None,
     annotation_info: Dict[str, str | bool] | None = None,
@@ -895,6 +897,9 @@ def wrapup_atlas_from_data(
     atlas_packager : str or None
         Credit for those responsible for converting the atlas
         into the BrainGlobe format.
+    license : dict, optional
+        License metadata in the form ``{"license": license_short_name,
+        "link_to_license": url}``. Defaults to ``None``.
     hemispheres_stack : ValidComponentData | None, optional
         Hemisphere stack for the atlas.
         If str or Path, will be read with tifffile.
@@ -1066,6 +1071,7 @@ def wrapup_atlas_from_data(
         structures_list=structures_list,
         meshes_dict=meshes_dict,
         atlas_packager=atlas_packager,
+        license=license,
         hemispheres_stack=hemispheres_stack,
         additional_references=additional_template_list,
         additional_metadata=additional_metadata,

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -163,6 +163,11 @@ class Atlas:
         return tuple(self.metadata["resolution"])
 
     @property
+    def license(self):
+        """Return the atlas license metadata, if provided."""
+        return self.metadata.get("license")
+
+    @property
     def _annotation_masks_path(self) -> Path:
         annotation_location = self.metadata["annotation_set"]["location"][1:]
         return self.root_dir / annotation_location / V3_ANNOTATION_MASKS_NAME

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -35,6 +35,18 @@ def test_initialization(atlas):
     assert atlas.shape == (132, 80, 114)
     assert atlas.resolution == (100.0, 100.0, 100.0)
     assert atlas.shape_um == (13200.0, 8000.0, 11400.0)
+    assert atlas.license is None
+
+
+def test_license_metadata(atlas):
+    """Atlas license metadata is available as a property."""
+    license_metadata = {
+        "license": "CC-BY-4.0",
+        "link_to_license": "https://creativecommons.org/licenses/by/4.0/",
+    }
+    atlas.metadata["license"] = license_metadata
+
+    assert atlas.license == license_metadata
 
 
 def test_additional_ref_dict(atlas):

--- a/tests/atlasgen/test_metadata_utils.py
+++ b/tests/atlasgen/test_metadata_utils.py
@@ -205,6 +205,11 @@ def test_generate_metadata_dict_with_unlicensed_marker(
             "license must be a string",
         ),
         (
+            {"license": "CC-BY-4.0", "link_to_license": 4},
+            TypeError,
+            "link_to_license must be a string or None",
+        ),
+        (
             {
                 "license": "CC-BY-4.0",
                 "link_to_license": "https://example.com",

--- a/tests/atlasgen/test_metadata_utils.py
+++ b/tests/atlasgen/test_metadata_utils.py
@@ -178,6 +178,42 @@ def test_generate_metadata_dict_with_license(metadata_input_template):
 
 
 @pytest.mark.parametrize(
+    "license_metadata, error, message",
+    [
+        ("CC-BY-4.0", TypeError, "must be a dictionary"),
+        (
+            {"license": "CC-BY-4.0"},
+            ValueError,
+            "missing required fields: link_to_license",
+        ),
+        (
+            {"license": 4, "link_to_license": "https://example.com"},
+            TypeError,
+            "values must be strings",
+        ),
+        (
+            {
+                "license": "CC-BY-4.0",
+                "link_to_license": "https://example.com",
+                "copyright_holder": "Example Institute",
+            },
+            ValueError,
+            "unexpected fields: copyright_holder",
+        ),
+    ],
+)
+def test_generate_metadata_dict_rejects_invalid_license(
+    metadata_input_template, license_metadata, error, message
+):
+    """License metadata must contain the required string fields."""
+    metadata_input_template["citation"] = "unpublished"
+    metadata_input_template["license"] = license_metadata
+
+    with pytest.raises(error, match=message):
+        generate_metadata_dict(**metadata_input_template)
+
+
+@pytest.mark.parametrize(
     ["metadata", "error"],
     [
         pytest.param(

--- a/tests/atlasgen/test_metadata_utils.py
+++ b/tests/atlasgen/test_metadata_utils.py
@@ -66,6 +66,12 @@ def metadata_input_template():
         "shape": [172, 256, 154],  # Keep as list/tuple input type
         "additional_references": [],
         "atlas_packager": "people who packaged the atlas",
+        "license": {
+            "license": "CC-BY-4.0",
+            "link_to_license": (
+                "https://creativecommons.org/licenses/by/4.0/"
+            ),
+        },
         "coordinate_space": coordinate_space,
         "terminology": terminology,
         "annotation_set": annotation_set,
@@ -99,6 +105,7 @@ def test_generate_metadata_dict(metadata_input_template):
         "shape": "shape",
         "additional_references": "additional_references",
         "atlas_packager": "atlas_packager",
+        "license": "license",
         "coordinate_space": "coordinate_space",
         "terminology": "terminology",
         "annotation_set": "annotation_set",
@@ -148,6 +155,26 @@ def test_generate_metadata_dict(metadata_input_template):
     assert (
         output_keys == expected_keys
     ), f"Output keys {output_keys} do not match expected keys {expected_keys}"
+
+
+def test_generate_metadata_dict_without_license(metadata_input_template):
+    """Unset license metadata is stored as ``None``."""
+    metadata_input_template["license"] = None
+    metadata_input_template["citation"] = "unpublished"
+
+    output = generate_metadata_dict(**metadata_input_template)
+
+    assert output["license"] is None
+
+
+def test_generate_metadata_dict_with_license(metadata_input_template):
+    """License metadata is included unchanged."""
+    metadata_input_template["citation"] = "unpublished"
+    expected = metadata_input_template["license"]
+
+    output = generate_metadata_dict(**metadata_input_template)
+
+    assert output["license"] == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/atlasgen/test_metadata_utils.py
+++ b/tests/atlasgen/test_metadata_utils.py
@@ -177,6 +177,19 @@ def test_generate_metadata_dict_with_license(metadata_input_template):
     assert output["license"] == expected
 
 
+def test_generate_metadata_dict_with_unlicensed_marker(
+    metadata_input_template,
+):
+    """An explicitly unlicensed atlas may omit a license URL."""
+    expected = {"license": "unlicensed", "link_to_license": None}
+    metadata_input_template["license"] = expected
+    metadata_input_template["citation"] = "unpublished"
+
+    output = generate_metadata_dict(**metadata_input_template)
+
+    assert output["license"] == expected
+
+
 @pytest.mark.parametrize(
     "license_metadata, error, message",
     [
@@ -189,7 +202,7 @@ def test_generate_metadata_dict_with_license(metadata_input_template):
         (
             {"license": 4, "link_to_license": "https://example.com"},
             TypeError,
-            "values must be strings",
+            "license must be a string",
         ),
         (
             {
@@ -205,7 +218,7 @@ def test_generate_metadata_dict_with_license(metadata_input_template):
 def test_generate_metadata_dict_rejects_invalid_license(
     metadata_input_template, license_metadata, error, message
 ):
-    """License metadata must contain the required string fields."""
+    """License metadata must contain valid required fields."""
     metadata_input_template["citation"] = "unpublished"
     metadata_input_template["license"] = license_metadata
 


### PR DESCRIPTION
This adds an optional metadata field to atlas wrapup for inclusion of a license. The most useful way to do this i thought would be to have a license short name, however many atlases use a custom atlas. as a compromise I propose this as the best way to integrate licensing. 

```python
        "license": {
            "license": "CC-BY-4.0",
            "link_to_license": (
                "https://creativecommons.org/licenses/by/4.0/"
            ),
        }
```

Ive also made this directly accessible via atlas.license.


In cases where its not set atlas.license will return None. This is distinct from 

```python
        "license": {
            "license": "unlicensed"
            "link_to_license": (
                None
            ),
        }
```


In cases of a custom license we can say 

```python
        "license": {
            "license": "custom"
            "link_to_license": (
                "https://alleninstitute.org/legal/terms-of-use"
            ),
        }
```