### PR TITLE
Report atlas download progress to fn_update

### DIFF
--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 import s3fs
-from fsspec.callbacks import TqdmCallback
+from fsspec.callbacks import Callback, TqdmCallback
 from rich import print as rprint
 from rich.console import Console
 
@@ -38,6 +38,58 @@ def _version_tuple_from_str(version_str):
 
 def _version_str_from_tuple(version_tuple: Tuple[int, ...]) -> str:
     return "_".join(str(num) for num in version_tuple)
+
+
+class _ProgressCallback(TqdmCallback):
+    """Show a tqdm bar and report progress to an external handler.
+
+    ``fsspec`` drives the callback passed to ``get`` with a file count, and
+    asks it for a per-file callback through ``branched`` which is driven with
+    a byte count. ``fn_update`` is documented to take completed and total
+    bytes, so it is attached to the branched callbacks.
+
+    Parameters
+    ----------
+    fn_update : Callable
+        Handler called as ``fn_update(completed, total)`` with the bytes
+        transferred so far and the total size of the file being fetched.
+    """
+
+    def __init__(self, fn_update: Callable[[int, int], None], **kwargs):
+        super().__init__(**kwargs)
+        self.fn_update = fn_update
+
+    def branched(self, path_1, path_2, **kwargs):
+        """Return a per-file callback that reports bytes to ``fn_update``."""
+        kwargs["callback"] = Callback(
+            hooks={
+                "fn_update": lambda size, value, **_: self.fn_update(
+                    value, size or 0
+                )
+            }
+        )
+        return super().branched(path_1, path_2, **kwargs)
+
+
+def _download_callback(
+    fn_update: Optional[Callable[[int, int], None]],
+) -> TqdmCallback:
+    """Build the fsspec callback used for a single atlas download step.
+
+    Parameters
+    ----------
+    fn_update : Callable, optional
+        Handler to report download progress to. If None, only the tqdm
+        progress bar is shown.
+
+    Returns
+    -------
+    TqdmCallback
+        The callback to pass to ``fsspec``.
+    """
+    if fn_update is None:
+        return TqdmCallback()
+    return _ProgressCallback(fn_update)
 
 
 class BrainGlobeAtlas(core.Atlas):
@@ -246,7 +298,11 @@ class BrainGlobeAtlas(core.Atlas):
             f"Downloading {self.atlas_name} atlas "
             f"v{remote_version_str.replace('_', '.')} manifest:"
         )
-        self.fs.get(remote_path, local_path, callback=TqdmCallback())
+        self.fs.get(
+            remote_path,
+            local_path,
+            callback=_download_callback(self.fn_update),
+        )
         self.metadata = read_json(local_path)
 
         try:
@@ -265,7 +321,7 @@ class BrainGlobeAtlas(core.Atlas):
                     remote_terminology_path,
                     local_terminology_path,
                     recursive=True,
-                    callback=TqdmCallback(),
+                    callback=_download_callback(self.fn_update),
                 )
 
             # Download coordinate space files
@@ -285,7 +341,7 @@ class BrainGlobeAtlas(core.Atlas):
                     remote_coordspace_path,
                     local_coordspace_path,
                     recursive=True,
-                    callback=TqdmCallback(),
+                    callback=_download_callback(self.fn_update),
                 )
 
             # Download annotation metadata files
@@ -307,7 +363,7 @@ class BrainGlobeAtlas(core.Atlas):
                 self.fs.get(
                     remote_root_metadata_path,
                     local_annotation_path / V3_ANNOTATION_NAME,
-                    callback=TqdmCallback(),
+                    callback=_download_callback(self.fn_update),
                 )
                 mesh_path = local_annotation_path / V3_MESHES_DIRECTORY
                 mesh_path.mkdir(parents=True, exist_ok=True)
@@ -324,7 +380,7 @@ class BrainGlobeAtlas(core.Atlas):
                     self.fs.get(
                         remote_masks_metadata,
                         str(local_annotation_path / V3_ANNOTATION_MASKS_NAME),
-                        callback=TqdmCallback(),
+                        callback=_download_callback(self.fn_update),
                     )
                     masks_annotation_values_path = (
                         annotation_location + f"/{V3_ANNOTATION_MASKS_NAME}"
@@ -336,7 +392,7 @@ class BrainGlobeAtlas(core.Atlas):
                     self.fs.get(
                         remote_masks_annotation_values_path,
                         str(local_annotation_path / V3_ANNOTATION_MASKS_NAME),
-                        callback=TqdmCallback(),
+                        callback=_download_callback(self.fn_update),
                         recursive=True,
                     )
                 except FileNotFoundError as e:
@@ -357,7 +413,7 @@ class BrainGlobeAtlas(core.Atlas):
                     self.fs.get(
                         remote_root_hemisphere_path,
                         local_annotation_path / V3_HEMISPHERES_NAME,
-                        callback=TqdmCallback(),
+                        callback=_download_callback(self.fn_update),
                     )
 
             # Download template metadata files
@@ -380,7 +436,7 @@ class BrainGlobeAtlas(core.Atlas):
                 self.fs.get(
                     remote_root_metadata_path,
                     local_template_path / V3_TEMPLATE_NAME,
-                    callback=TqdmCallback(),
+                    callback=_download_callback(self.fn_update),
                 )
 
             additional_reference_names = self.metadata.get(
@@ -405,7 +461,7 @@ class BrainGlobeAtlas(core.Atlas):
                     self.fs.get(
                         remote_root_metadata_path,
                         local_template_path / V3_TEMPLATE_NAME,
-                        callback=TqdmCallback(),
+                        callback=_download_callback(self.fn_update),
                     )
             # Reset local_full_name to ensure it is updated with new location
             self._local_full_name = None

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -12,7 +12,7 @@ from rich.console import Console
 
 from brainglobe_atlasapi import config, core
 from brainglobe_atlasapi.atlas_name import AtlasName
-from brainglobe_atlasapi.core import _download_callback
+from brainglobe_atlasapi.callback import _download_callback
 from brainglobe_atlasapi.descriptors import (
     V3_ANNOTATION_MAP_NAME,
     V3_ANNOTATION_MASKS_NAME,

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -58,9 +58,7 @@ class BrainGlobeAtlas(core.Atlas):
         instantiation and to suppress warnings.
     fn_update : Callable
         Handler function to update during download. Takes the number of files
-        fetched so far and the total number of files to fetch. An atlas is an
-        OME-Zarr store, so a byte count would tick through thousands of small
-        chunks and read as a stalling bar.
+        fetched so far and the total number of files to fetch.
     """
 
     def __init__(

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -12,7 +12,7 @@ from rich.console import Console
 
 from brainglobe_atlasapi import config, core
 from brainglobe_atlasapi.atlas_name import AtlasName
-from brainglobe_atlasapi.callback import _download_callback
+from brainglobe_atlasapi.callback import AtlasCallback
 from brainglobe_atlasapi.descriptors import (
     V3_ANNOTATION_MAP_NAME,
     V3_ANNOTATION_MASKS_NAME,
@@ -253,7 +253,7 @@ class BrainGlobeAtlas(core.Atlas):
         self.fs.get(
             remote_path,
             local_path,
-            callback=_download_callback(self.fn_update),
+            callback=AtlasCallback(self.fn_update),
         )
         self.metadata = read_json(local_path)
 
@@ -273,7 +273,7 @@ class BrainGlobeAtlas(core.Atlas):
                     remote_terminology_path,
                     local_terminology_path,
                     recursive=True,
-                    callback=_download_callback(self.fn_update),
+                    callback=AtlasCallback(self.fn_update),
                 )
 
             # Download coordinate space files
@@ -293,7 +293,7 @@ class BrainGlobeAtlas(core.Atlas):
                     remote_coordspace_path,
                     local_coordspace_path,
                     recursive=True,
-                    callback=_download_callback(self.fn_update),
+                    callback=AtlasCallback(self.fn_update),
                 )
 
             # Download annotation metadata files
@@ -315,7 +315,7 @@ class BrainGlobeAtlas(core.Atlas):
                 self.fs.get(
                     remote_root_metadata_path,
                     local_annotation_path / V3_ANNOTATION_NAME,
-                    callback=_download_callback(self.fn_update),
+                    callback=AtlasCallback(self.fn_update),
                 )
                 mesh_path = local_annotation_path / V3_MESHES_DIRECTORY
                 mesh_path.mkdir(parents=True, exist_ok=True)
@@ -332,7 +332,7 @@ class BrainGlobeAtlas(core.Atlas):
                     self.fs.get(
                         remote_masks_metadata,
                         str(local_annotation_path / V3_ANNOTATION_MASKS_NAME),
-                        callback=_download_callback(self.fn_update),
+                        callback=AtlasCallback(self.fn_update),
                     )
                     masks_annotation_values_path = (
                         annotation_location + f"/{V3_ANNOTATION_MASKS_NAME}"
@@ -344,7 +344,7 @@ class BrainGlobeAtlas(core.Atlas):
                     self.fs.get(
                         remote_masks_annotation_values_path,
                         str(local_annotation_path / V3_ANNOTATION_MASKS_NAME),
-                        callback=_download_callback(self.fn_update),
+                        callback=AtlasCallback(self.fn_update),
                         recursive=True,
                     )
                 except FileNotFoundError as e:
@@ -365,7 +365,7 @@ class BrainGlobeAtlas(core.Atlas):
                     self.fs.get(
                         remote_root_hemisphere_path,
                         local_annotation_path / V3_HEMISPHERES_NAME,
-                        callback=_download_callback(self.fn_update),
+                        callback=AtlasCallback(self.fn_update),
                     )
 
             # Download template metadata files
@@ -388,7 +388,7 @@ class BrainGlobeAtlas(core.Atlas):
                 self.fs.get(
                     remote_root_metadata_path,
                     local_template_path / V3_TEMPLATE_NAME,
-                    callback=_download_callback(self.fn_update),
+                    callback=AtlasCallback(self.fn_update),
                 )
 
             additional_reference_names = self.metadata.get(
@@ -413,7 +413,7 @@ class BrainGlobeAtlas(core.Atlas):
                     self.fs.get(
                         remote_root_metadata_path,
                         local_template_path / V3_TEMPLATE_NAME,
-                        callback=_download_callback(self.fn_update),
+                        callback=AtlasCallback(self.fn_update),
                     )
             # Reset local_full_name to ensure it is updated with new location
             self._local_full_name = None

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -57,8 +57,10 @@ class BrainGlobeAtlas(core.Atlas):
         this to False to avoid waiting for remote server response on atlas
         instantiation and to suppress warnings.
     fn_update : Callable
-        Handler function to update during download. Takes completed and total
-        bytes.
+        Handler function to update during download. Takes the number of files
+        fetched so far and the total number of files to fetch. An atlas is an
+        OME-Zarr store, so a byte count would tick through thousands of small
+        chunks and read as a stalling bar.
     """
 
     def __init__(

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 import s3fs
-from fsspec.callbacks import Callback, TqdmCallback
 from rich import print as rprint
 from rich.console import Console
 
 from brainglobe_atlasapi import config, core
 from brainglobe_atlasapi.atlas_name import AtlasName
+from brainglobe_atlasapi.core import _download_callback
 from brainglobe_atlasapi.descriptors import (
     V3_ANNOTATION_MAP_NAME,
     V3_ANNOTATION_MASKS_NAME,
@@ -38,58 +38,6 @@ def _version_tuple_from_str(version_str):
 
 def _version_str_from_tuple(version_tuple: Tuple[int, ...]) -> str:
     return "_".join(str(num) for num in version_tuple)
-
-
-class _ProgressCallback(TqdmCallback):
-    """Show a tqdm bar and report progress to an external handler.
-
-    ``fsspec`` drives the callback passed to ``get`` with a file count, and
-    asks it for a per-file callback through ``branched`` which is driven with
-    a byte count. ``fn_update`` is documented to take completed and total
-    bytes, so it is attached to the branched callbacks.
-
-    Parameters
-    ----------
-    fn_update : Callable
-        Handler called as ``fn_update(completed, total)`` with the bytes
-        transferred so far and the total size of the file being fetched.
-    """
-
-    def __init__(self, fn_update: Callable[[int, int], None], **kwargs):
-        super().__init__(**kwargs)
-        self.fn_update = fn_update
-
-    def branched(self, path_1, path_2, **kwargs):
-        """Return a per-file callback that reports bytes to ``fn_update``."""
-        kwargs["callback"] = Callback(
-            hooks={
-                "fn_update": lambda size, value, **_: self.fn_update(
-                    value, size or 0
-                )
-            }
-        )
-        return super().branched(path_1, path_2, **kwargs)
-
-
-def _download_callback(
-    fn_update: Optional[Callable[[int, int], None]],
-) -> TqdmCallback:
-    """Build the fsspec callback used for a single atlas download step.
-
-    Parameters
-    ----------
-    fn_update : Callable, optional
-        Handler to report download progress to. If None, only the tqdm
-        progress bar is shown.
-
-    Returns
-    -------
-    TqdmCallback
-        The callback to pass to ``fsspec``.
-    """
-    if fn_update is None:
-        return TqdmCallback()
-    return _ProgressCallback(fn_update)
 
 
 class BrainGlobeAtlas(core.Atlas):
@@ -165,7 +113,9 @@ class BrainGlobeAtlas(core.Atlas):
                     "download."
                 )
 
-        super().__init__(self.brainglobe_dir / self.local_full_name)
+        super().__init__(
+            self.brainglobe_dir / self.local_full_name, fn_update=fn_update
+        )
 
         if check_latest:
             self.check_latest_version()

--- a/brainglobe_atlasapi/callback.py
+++ b/brainglobe_atlasapi/callback.py
@@ -6,51 +6,36 @@ from typing import Optional
 from fsspec.callbacks import TqdmCallback
 
 
-class _ProgressCallback(TqdmCallback):
-    """Show a tqdm bar and report progress to an external handler.
+class AtlasCallback(TqdmCallback):
+    """Show a tqdm bar for an atlas download and report progress onwards.
 
-    ``fsspec`` drives the callback passed to ``get`` with a file count, and
-    that count is what is reported. An atlas is an OME-Zarr store, so a byte
-    count would tick through thousands of small chunks and read as a stalling
-    bar, while the file count advances once per file.
-
-    ``TqdmCallback`` replaces :meth:`fsspec.callbacks.Callback.call` with one
-    that only drives the bar and never runs ``hooks``, so the handler is
-    invoked from an override rather than passed in as a hook.
-
-    Parameters
-    ----------
-    fn_update : Callable
-        Handler called as ``fn_update(completed, total)`` with the number of
-        files fetched so far and the total number of files to fetch.
-    """
-
-    def __init__(self, fn_update: Callable[[int, int], None], **kwargs):
-        super().__init__(**kwargs)
-        self.fn_update = fn_update
-
-    def call(self, *args, **kwargs):
-        """Advance the tqdm bar, then report the file count to the handler."""
-        super().call(*args, **kwargs)
-        self.fn_update(self.value, self.size or 0)
-
-
-def _download_callback(
-    fn_update: Optional[Callable[[int, int], None]],
-) -> TqdmCallback:
-    """Build the fsspec callback used for a single atlas download step.
+    An atlas is an OME-Zarr store, so this reports the number of files fetched
+    rather than the number of bytes. Bytes would tick through thousands of
+    small chunks and read as a stalling bar.
 
     Parameters
     ----------
     fn_update : Callable, optional
-        Handler to report download progress to. If None, only the tqdm
-        progress bar is shown.
-
-    Returns
-    -------
-    TqdmCallback
-        The callback to pass to ``fsspec``.
+        Handler called as ``fn_update(completed, total)`` with the number of
+        files fetched so far and the total number of files to fetch. If None,
+        only the tqdm progress bar is shown.
     """
-    if fn_update is None:
-        return TqdmCallback()
-    return _ProgressCallback(fn_update)
+
+    def __init__(
+        self,
+        fn_update: Optional[Callable[[int, int], None]] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.fn_update = fn_update
+
+    def call(self, *args, **kwargs):
+        """Advance the tqdm bar, then report the file count to the handler.
+
+        ``TqdmCallback`` overrides :meth:`fsspec.callbacks.Callback.call` with
+        a version that never runs ``hooks``, so the handler has to be called
+        from here rather than registered as one.
+        """
+        super().call(*args, **kwargs)
+        if self.fn_update:
+            self.fn_update(self.value, self.size or 0)

--- a/brainglobe_atlasapi/callback.py
+++ b/brainglobe_atlasapi/callback.py
@@ -1,0 +1,58 @@
+"""Module containing the fsspec callbacks used to report download progress."""
+
+from collections.abc import Callable
+from typing import Optional
+
+from fsspec.callbacks import Callback, TqdmCallback
+
+
+class _ProgressCallback(TqdmCallback):
+    """Show a tqdm bar and report progress to an external handler.
+
+    ``fsspec`` drives the callback passed to ``get`` with a file count, and
+    asks it for a per-file callback through ``branched`` which is driven with
+    a byte count. ``fn_update`` is documented to take completed and total
+    bytes, so it is attached to the branched callbacks.
+
+    Parameters
+    ----------
+    fn_update : Callable
+        Handler called as ``fn_update(completed, total)`` with the bytes
+        transferred so far and the total size of the file being fetched.
+    """
+
+    def __init__(self, fn_update: Callable[[int, int], None], **kwargs):
+        super().__init__(**kwargs)
+        self.fn_update = fn_update
+
+    def branched(self, path_1, path_2, **kwargs):
+        """Return a per-file callback that reports bytes to ``fn_update``."""
+        kwargs["callback"] = Callback(
+            hooks={
+                "fn_update": lambda size, value, **_: self.fn_update(
+                    value, size or 0
+                )
+            }
+        )
+        return super().branched(path_1, path_2, **kwargs)
+
+
+def _download_callback(
+    fn_update: Optional[Callable[[int, int], None]],
+) -> TqdmCallback:
+    """Build the fsspec callback used for a single atlas download step.
+
+    Parameters
+    ----------
+    fn_update : Callable, optional
+        Handler to report download progress to. If None, only the tqdm
+        progress bar is shown.
+
+    Returns
+    -------
+    TqdmCallback
+        The callback to pass to ``fsspec``.
+    """
+    if fn_update is None:
+        return TqdmCallback()
+    return _ProgressCallback(fn_update)

--- a/brainglobe_atlasapi/callback.py
+++ b/brainglobe_atlasapi/callback.py
@@ -3,38 +3,36 @@
 from collections.abc import Callable
 from typing import Optional
 
-from fsspec.callbacks import Callback, TqdmCallback
+from fsspec.callbacks import TqdmCallback
 
 
 class _ProgressCallback(TqdmCallback):
     """Show a tqdm bar and report progress to an external handler.
 
     ``fsspec`` drives the callback passed to ``get`` with a file count, and
-    asks it for a per-file callback through ``branched`` which is driven with
-    a byte count. ``fn_update`` is documented to take completed and total
-    bytes, so it is attached to the branched callbacks.
+    that count is what is reported. An atlas is an OME-Zarr store, so a byte
+    count would tick through thousands of small chunks and read as a stalling
+    bar, while the file count advances once per file.
+
+    ``TqdmCallback`` replaces :meth:`fsspec.callbacks.Callback.call` with one
+    that only drives the bar and never runs ``hooks``, so the handler is
+    invoked from an override rather than passed in as a hook.
 
     Parameters
     ----------
     fn_update : Callable
-        Handler called as ``fn_update(completed, total)`` with the bytes
-        transferred so far and the total size of the file being fetched.
+        Handler called as ``fn_update(completed, total)`` with the number of
+        files fetched so far and the total number of files to fetch.
     """
 
     def __init__(self, fn_update: Callable[[int, int], None], **kwargs):
         super().__init__(**kwargs)
         self.fn_update = fn_update
 
-    def branched(self, path_1, path_2, **kwargs):
-        """Return a per-file callback that reports bytes to ``fn_update``."""
-        kwargs["callback"] = Callback(
-            hooks={
-                "fn_update": lambda size, value, **_: self.fn_update(
-                    value, size or 0
-                )
-            }
-        )
-        return super().branched(path_1, path_2, **kwargs)
+    def call(self, *args, **kwargs):
+        """Advance the tqdm bar, then report the file count to the handler."""
+        super().call(*args, **kwargs)
+        self.fn_update(self.value, self.size or 0)
 
 
 def _download_callback(

--- a/brainglobe_atlasapi/callback.py
+++ b/brainglobe_atlasapi/callback.py
@@ -10,8 +10,7 @@ class AtlasCallback(TqdmCallback):
     """Show a tqdm bar for an atlas download and report progress onwards.
 
     An atlas is an OME-Zarr store, so this reports the number of files fetched
-    rather than the number of bytes. Bytes would tick through thousands of
-    small chunks and read as a stalling bar.
+    rather than the number of bytes.
 
     Parameters
     ----------

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -20,7 +20,7 @@ import s3fs
 import zarr
 from brainglobe_space import AnatomicalSpace
 
-from brainglobe_atlasapi.callback import _download_callback
+from brainglobe_atlasapi.callback import AtlasCallback
 from brainglobe_atlasapi.descriptors import (
     ANNOTATION_DTYPE,
     ATLAS_ORIENTATION,
@@ -230,7 +230,7 @@ class Atlas:
                 remote_path,
                 resolution_path,
                 recursive=True,
-                callback=_download_callback(self.fn_update),
+                callback=AtlasCallback(self.fn_update),
             )
 
         self._template = multiscale.images[
@@ -278,7 +278,7 @@ class Atlas:
                 remote_path,
                 resolution_path,
                 recursive=True,
-                callback=_download_callback(self.fn_update),
+                callback=AtlasCallback(self.fn_update),
             )
 
         self._annotation = multiscale.images[
@@ -339,7 +339,7 @@ class Atlas:
                     remote_path,
                     resolution_path,
                     recursive=True,
-                    callback=_download_callback(self.fn_update),
+                    callback=AtlasCallback(self.fn_update),
                 )
 
             self._hemispheres = multiscale.images[
@@ -725,7 +725,7 @@ class Atlas:
                     remote_path,
                     local_path,
                     recursive=True,
-                    callback=_download_callback(self.fn_update),
+                    callback=AtlasCallback(self.fn_update),
                 )
             except FileNotFoundError as e:
                 raise FileNotFoundError(
@@ -820,7 +820,7 @@ class AdditionalRefDict(UserDict):
                     remote_path,
                     resolution_path,
                     recursive=True,
-                    callback=_download_callback(self.fn_update),
+                    callback=AtlasCallback(self.fn_update),
                 )
             self.data[key] = multiscale.images[pyramid_level].data.compute()
 

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -56,8 +56,6 @@ def _determine_pyramid_level(
     raise ValueError(f"Requested resolution {resolution} um is invalid.")
 
 
-
-
 class Atlas:
     """Base class to handle atlases in BrainGlobe.
 

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -147,6 +147,7 @@ class Atlas:
                 references_list=additional_references,
                 data_path=self.root_dir,
                 resolution=self.resolution,
+                fn_update=self.fn_update,
             )
         except KeyError:
             warnings.warn(
@@ -750,6 +751,7 @@ class AdditionalRefDict(UserDict):
         references_list: List[Dict[str, str]],
         data_path,
         resolution: Tuple[float, float, float],
+        fn_update: Optional[Callable] = None,
         *args,
         **kwargs,
     ):
@@ -757,6 +759,10 @@ class AdditionalRefDict(UserDict):
         self.references_names = [ref["name"] for ref in references_list]
         self.references_dict = {ref["name"]: ref for ref in references_list}
         self.resolution = resolution
+        # An additional reference is fetched lazily on first access, long after
+        # the owning `Atlas` was built, so the handler has to be carried here
+        # rather than read off the atlas at download time.
+        self.fn_update = fn_update
 
         super().__init__(*args, **kwargs)
 

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -2,10 +2,12 @@
 
 import warnings
 from collections import UserDict, deque
+from collections.abc import Callable
 from pathlib import Path
 from typing import (
     Dict,
     List,
+    Optional,
     Tuple,
     Union,
 )
@@ -17,7 +19,7 @@ import pandas as pd
 import s3fs
 import zarr
 from brainglobe_space import AnatomicalSpace
-from fsspec.callbacks import TqdmCallback
+from fsspec.callbacks import Callback, TqdmCallback
 
 from brainglobe_atlasapi.descriptors import (
     ANNOTATION_DTYPE,
@@ -54,6 +56,58 @@ def _determine_pyramid_level(
     raise ValueError(f"Requested resolution {resolution} um is invalid.")
 
 
+class _ProgressCallback(TqdmCallback):
+    """Show a tqdm bar and report progress to an external handler.
+
+    ``fsspec`` drives the callback passed to ``get`` with a file count, and
+    asks it for a per-file callback through ``branched`` which is driven with
+    a byte count. ``fn_update`` is documented to take completed and total
+    bytes, so it is attached to the branched callbacks.
+
+    Parameters
+    ----------
+    fn_update : Callable
+        Handler called as ``fn_update(completed, total)`` with the bytes
+        transferred so far and the total size of the file being fetched.
+    """
+
+    def __init__(self, fn_update: Callable[[int, int], None], **kwargs):
+        super().__init__(**kwargs)
+        self.fn_update = fn_update
+
+    def branched(self, path_1, path_2, **kwargs):
+        """Return a per-file callback that reports bytes to ``fn_update``."""
+        kwargs["callback"] = Callback(
+            hooks={
+                "fn_update": lambda size, value, **_: self.fn_update(
+                    value, size or 0
+                )
+            }
+        )
+        return super().branched(path_1, path_2, **kwargs)
+
+
+def _download_callback(
+    fn_update: Optional[Callable[[int, int], None]],
+) -> TqdmCallback:
+    """Build the fsspec callback used for a single atlas download step.
+
+    Parameters
+    ----------
+    fn_update : Callable, optional
+        Handler to report download progress to. If None, only the tqdm
+        progress bar is shown.
+
+    Returns
+    -------
+    TqdmCallback
+        The callback to pass to ``fsspec``.
+    """
+    if fn_update is None:
+        return TqdmCallback()
+    return _ProgressCallback(fn_update)
+
+
 class Atlas:
     """Base class to handle atlases in BrainGlobe.
 
@@ -66,7 +120,11 @@ class Atlas:
     left_hemisphere_value = 1
     right_hemisphere_value = 2
 
-    def __init__(self, path):
+    def __init__(self, path, fn_update: Optional[Callable] = None):
+        # Progress handler shared by every lazy fetch below, so a caller that
+        # passes one sees byte progress for the pyramid levels too and not only
+        # for the initial download.
+        self.fn_update = fn_update
         self._template_pyramid_level = 0
         self._annotation_pyramid_level = 0
         self.fs = s3fs.S3FileSystem(anon=True)
@@ -125,7 +183,7 @@ class Atlas:
 
         # Add entry for file paths:
         for struct in structures_list:
-            struct["mesh_filename"] = meshes_path / f'{struct["id"]}'
+            struct["mesh_filename"] = meshes_path / f"{struct['id']}"
 
         self.structures = StructuresDict(structures_list)
 
@@ -227,7 +285,7 @@ class Atlas:
                 remote_path,
                 resolution_path,
                 recursive=True,
-                callback=TqdmCallback(),
+                callback=_download_callback(self.fn_update),
             )
 
         self._template = multiscale.images[
@@ -275,7 +333,7 @@ class Atlas:
                 remote_path,
                 resolution_path,
                 recursive=True,
-                callback=TqdmCallback(),
+                callback=_download_callback(self.fn_update),
             )
 
         self._annotation = multiscale.images[
@@ -336,7 +394,7 @@ class Atlas:
                     remote_path,
                     resolution_path,
                     recursive=True,
-                    callback=TqdmCallback(),
+                    callback=_download_callback(self.fn_update),
                 )
 
             self._hemispheres = multiscale.images[
@@ -657,7 +715,7 @@ class Atlas:
                 )
             except IndexError:
                 raise ValueError(
-                    f'Structure {self.structures[structure]["acronym"]} '
+                    f"Structure {self.structures[structure]['acronym']} "
                     f"has no descendants at hierarchy level {hierarchy_level}"
                 )
 
@@ -722,7 +780,7 @@ class Atlas:
                     remote_path,
                     local_path,
                     recursive=True,
-                    callback=TqdmCallback(),
+                    callback=_download_callback(self.fn_update),
                 )
             except FileNotFoundError as e:
                 raise FileNotFoundError(
@@ -817,7 +875,7 @@ class AdditionalRefDict(UserDict):
                     remote_path,
                     resolution_path,
                     recursive=True,
-                    callback=TqdmCallback(),
+                    callback=_download_callback(self.fn_update),
                 )
             self.data[key] = multiscale.images[pyramid_level].data.compute()
 

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -19,8 +19,8 @@ import pandas as pd
 import s3fs
 import zarr
 from brainglobe_space import AnatomicalSpace
-from fsspec.callbacks import Callback, TqdmCallback
 
+from brainglobe_atlasapi.callback import _download_callback
 from brainglobe_atlasapi.descriptors import (
     ANNOTATION_DTYPE,
     ATLAS_ORIENTATION,
@@ -56,56 +56,6 @@ def _determine_pyramid_level(
     raise ValueError(f"Requested resolution {resolution} um is invalid.")
 
 
-class _ProgressCallback(TqdmCallback):
-    """Show a tqdm bar and report progress to an external handler.
-
-    ``fsspec`` drives the callback passed to ``get`` with a file count, and
-    asks it for a per-file callback through ``branched`` which is driven with
-    a byte count. ``fn_update`` is documented to take completed and total
-    bytes, so it is attached to the branched callbacks.
-
-    Parameters
-    ----------
-    fn_update : Callable
-        Handler called as ``fn_update(completed, total)`` with the bytes
-        transferred so far and the total size of the file being fetched.
-    """
-
-    def __init__(self, fn_update: Callable[[int, int], None], **kwargs):
-        super().__init__(**kwargs)
-        self.fn_update = fn_update
-
-    def branched(self, path_1, path_2, **kwargs):
-        """Return a per-file callback that reports bytes to ``fn_update``."""
-        kwargs["callback"] = Callback(
-            hooks={
-                "fn_update": lambda size, value, **_: self.fn_update(
-                    value, size or 0
-                )
-            }
-        )
-        return super().branched(path_1, path_2, **kwargs)
-
-
-def _download_callback(
-    fn_update: Optional[Callable[[int, int], None]],
-) -> TqdmCallback:
-    """Build the fsspec callback used for a single atlas download step.
-
-    Parameters
-    ----------
-    fn_update : Callable, optional
-        Handler to report download progress to. If None, only the tqdm
-        progress bar is shown.
-
-    Returns
-    -------
-    TqdmCallback
-        The callback to pass to ``fsspec``.
-    """
-    if fn_update is None:
-        return TqdmCallback()
-    return _ProgressCallback(fn_update)
 
 
 class Atlas:
@@ -121,9 +71,6 @@ class Atlas:
     right_hemisphere_value = 2
 
     def __init__(self, path, fn_update: Optional[Callable] = None):
-        # Progress handler shared by every lazy fetch below, so a caller that
-        # passes one sees byte progress for the pyramid levels too and not only
-        # for the initial download.
         self.fn_update = fn_update
         self._template_pyramid_level = 0
         self._annotation_pyramid_level = 0

--- a/tests/atlasapi/test_bg_atlas.py
+++ b/tests/atlasapi/test_bg_atlas.py
@@ -106,7 +106,7 @@ def test_str(atlas, capsys):
     [pytest.param(False, id="one file"), pytest.param(True, id="directory")],
 )
 def test_download_callback_reports_file_counts(tmp_path, recursive):
-    """`_download_callback` reports fetched file counts to `fn_update`.
+    """`AtlasCallback` reports fetched file counts to `fn_update`.
 
     An atlas is an OME-Zarr store, so byte progress would tick through
     thousands of small chunks. The file count is the useful proxy.
@@ -118,7 +118,7 @@ def test_download_callback_reports_file_counts(tmp_path, recursive):
     recursive : bool
         Whether to fetch a whole directory or a single file.
     """
-    from brainglobe_atlasapi.callback import _download_callback
+    from brainglobe_atlasapi.callback import AtlasCallback
 
     calls = []
     memory_fs = fsspec.filesystem("memory")
@@ -130,7 +130,7 @@ def test_download_callback_reports_file_counts(tmp_path, recursive):
         source,
         str(tmp_path / "destination"),
         recursive=recursive,
-        callback=_download_callback(
+        callback=AtlasCallback(
             lambda completed, total: calls.append((completed, total))
         ),
     )
@@ -151,8 +151,8 @@ def test_download_callback_reports_file_counts(tmp_path, recursive):
 
 
 def test_download_callback_without_fn_update(tmp_path):
-    """`_download_callback` still transfers files when no handler is given."""
-    from brainglobe_atlasapi.callback import _download_callback
+    """`AtlasCallback` still transfers files when no handler is given."""
+    from brainglobe_atlasapi.callback import AtlasCallback
 
     memory_fs = fsspec.filesystem("memory")
     memory_fs.pipe("/atlas/first.json", b"a" * 8)
@@ -160,7 +160,7 @@ def test_download_callback_without_fn_update(tmp_path):
     memory_fs.get(
         "/atlas/first.json",
         str(tmp_path / "first.json"),
-        callback=_download_callback(None),
+        callback=AtlasCallback(None),
     )
 
     assert (tmp_path / "first.json").read_bytes() == b"a" * 8

--- a/tests/atlasapi/test_bg_atlas.py
+++ b/tests/atlasapi/test_bg_atlas.py
@@ -115,7 +115,7 @@ def test_download_callback_reports_bytes(tmp_path, recursive):
     recursive : bool
         Whether to fetch a whole directory or a single file.
     """
-    from brainglobe_atlasapi.bg_atlas import _download_callback
+    from brainglobe_atlasapi.callback import _download_callback
 
     calls = []
     memory_fs = fsspec.filesystem("memory")
@@ -141,7 +141,7 @@ def test_download_callback_reports_bytes(tmp_path, recursive):
 
 def test_download_callback_without_fn_update(tmp_path):
     """`_download_callback` still transfers files when no handler is given."""
-    from brainglobe_atlasapi.bg_atlas import _download_callback
+    from brainglobe_atlasapi.callback import _download_callback
 
     memory_fs = fsspec.filesystem("memory")
     memory_fs.pipe("/atlas/first.json", b"a" * 8)

--- a/tests/atlasapi/test_bg_atlas.py
+++ b/tests/atlasapi/test_bg_atlas.py
@@ -105,8 +105,11 @@ def test_str(atlas, capsys):
     "recursive",
     [pytest.param(False, id="one file"), pytest.param(True, id="directory")],
 )
-def test_download_callback_reports_bytes(tmp_path, recursive):
-    """`_download_callback` reports transferred bytes to `fn_update`.
+def test_download_callback_reports_file_counts(tmp_path, recursive):
+    """`_download_callback` reports fetched file counts to `fn_update`.
+
+    An atlas is an OME-Zarr store, so byte progress would tick through
+    thousands of small chunks. The file count is the useful proxy.
 
     Parameters
     ----------
@@ -134,9 +137,17 @@ def test_download_callback_reports_bytes(tmp_path, recursive):
 
     assert calls, "fn_update was never called"
     assert all(0 <= completed <= total for completed, total in calls)
-    assert (4096, 4096) in calls
-    if recursive:
-        assert (2048, 2048) in calls
+
+    totals = {total for _, total in calls}
+    assert len(totals) == 1, f"the total moved during the fetch: {totals}"
+    total = totals.pop()
+
+    # The total is a file count, so it stays small and is never one of the
+    # 4096 or 2048 byte sizes written above. The exact number is left to
+    # fsspec, which counts the directory entry as well as its files.
+    assert total <= 10
+    assert total not in (4096, 2048)
+    assert calls[-1] == (total, total)
 
 
 def test_download_callback_without_fn_update(tmp_path):

--- a/tests/atlasapi/test_bg_atlas.py
+++ b/tests/atlasapi/test_bg_atlas.py
@@ -3,6 +3,7 @@
 import shutil
 from unittest.mock import PropertyMock, patch
 
+import fsspec
 import pytest
 
 import brainglobe_atlasapi
@@ -98,6 +99,80 @@ def test_str(atlas, capsys):
     expected_doi = "https://doi.org/10.1016/j.cell.2020.04.007"
     assert expected_doi in captured.out
     assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    "recursive",
+    [pytest.param(False, id="one file"), pytest.param(True, id="directory")],
+)
+def test_download_callback_reports_bytes(tmp_path, recursive):
+    """`_download_callback` reports transferred bytes to `fn_update`.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary path to fetch files into.
+    recursive : bool
+        Whether to fetch a whole directory or a single file.
+    """
+    from brainglobe_atlasapi.bg_atlas import _download_callback
+
+    calls = []
+    memory_fs = fsspec.filesystem("memory")
+    memory_fs.pipe("/atlas/first.json", b"a" * 4096)
+    memory_fs.pipe("/atlas/second.json", b"b" * 2048)
+
+    source = "/atlas/" if recursive else "/atlas/first.json"
+    memory_fs.get(
+        source,
+        str(tmp_path / "destination"),
+        recursive=recursive,
+        callback=_download_callback(
+            lambda completed, total: calls.append((completed, total))
+        ),
+    )
+
+    assert calls, "fn_update was never called"
+    assert all(0 <= completed <= total for completed, total in calls)
+    assert (4096, 4096) in calls
+    if recursive:
+        assert (2048, 2048) in calls
+
+
+def test_download_callback_without_fn_update(tmp_path):
+    """`_download_callback` still transfers files when no handler is given."""
+    from brainglobe_atlasapi.bg_atlas import _download_callback
+
+    memory_fs = fsspec.filesystem("memory")
+    memory_fs.pipe("/atlas/first.json", b"a" * 8)
+
+    memory_fs.get(
+        "/atlas/first.json",
+        str(tmp_path / "first.json"),
+        callback=_download_callback(None),
+    )
+
+    assert (tmp_path / "first.json").read_bytes() == b"a" * 8
+
+
+def test_fn_update_called_on_install(tmp_path):
+    """`fn_update` is called while an atlas is downloaded.
+
+    `BrainGlobeAtlas` accepts `fn_update` so that external progress bars can
+    follow an install, but the download used to ignore it entirely.
+    """
+    calls = []
+
+    BrainGlobeAtlas(
+        "example_mouse_100um",
+        brainglobe_dir=tmp_path,
+        check_latest=False,
+        fn_update=lambda completed, total: calls.append((completed, total)),
+    )
+
+    assert calls, "fn_update was not called during the atlas download"
+    assert all(0 <= completed <= total for completed, total in calls)
+    assert any(completed == total > 0 for completed, total in calls)
 
 
 def test_local_search(tmpdir):

--- a/tests/atlasapi/test_bg_atlas.py
+++ b/tests/atlasapi/test_bg_atlas.py
@@ -3,7 +3,6 @@
 import shutil
 from unittest.mock import PropertyMock, patch
 
-import fsspec
 import pytest
 
 import brainglobe_atlasapi
@@ -99,71 +98,6 @@ def test_str(atlas, capsys):
     expected_doi = "https://doi.org/10.1016/j.cell.2020.04.007"
     assert expected_doi in captured.out
     assert captured.err == ""
-
-
-@pytest.mark.parametrize(
-    "recursive",
-    [pytest.param(False, id="one file"), pytest.param(True, id="directory")],
-)
-def test_download_callback_reports_file_counts(tmp_path, recursive):
-    """`AtlasCallback` reports fetched file counts to `fn_update`.
-
-    An atlas is an OME-Zarr store, so byte progress would tick through
-    thousands of small chunks. The file count is the useful proxy.
-
-    Parameters
-    ----------
-    tmp_path : pathlib.Path
-        Temporary path to fetch files into.
-    recursive : bool
-        Whether to fetch a whole directory or a single file.
-    """
-    from brainglobe_atlasapi.callback import AtlasCallback
-
-    calls = []
-    memory_fs = fsspec.filesystem("memory")
-    memory_fs.pipe("/atlas/first.json", b"a" * 4096)
-    memory_fs.pipe("/atlas/second.json", b"b" * 2048)
-
-    source = "/atlas/" if recursive else "/atlas/first.json"
-    memory_fs.get(
-        source,
-        str(tmp_path / "destination"),
-        recursive=recursive,
-        callback=AtlasCallback(
-            lambda completed, total: calls.append((completed, total))
-        ),
-    )
-
-    assert calls, "fn_update was never called"
-    assert all(0 <= completed <= total for completed, total in calls)
-
-    totals = {total for _, total in calls}
-    assert len(totals) == 1, f"the total moved during the fetch: {totals}"
-    total = totals.pop()
-
-    # The total is a file count, so it stays small and is never one of the
-    # 4096 or 2048 byte sizes written above. The exact number is left to
-    # fsspec, which counts the directory entry as well as its files.
-    assert total <= 10
-    assert total not in (4096, 2048)
-    assert calls[-1] == (total, total)
-
-
-def test_download_callback_without_fn_update(tmp_path):
-    """`AtlasCallback` still transfers files when no handler is given."""
-    from brainglobe_atlasapi.callback import AtlasCallback
-
-    memory_fs = fsspec.filesystem("memory")
-    memory_fs.pipe("/atlas/first.json", b"a" * 8)
-
-    memory_fs.get(
-        "/atlas/first.json",
-        str(tmp_path / "first.json"),
-        callback=AtlasCallback(None),
-    )
-
-    assert (tmp_path / "first.json").read_bytes() == b"a" * 8
 
 
 def test_fn_update_called_on_install(tmp_path):

--- a/tests/atlasapi/test_callback.py
+++ b/tests/atlasapi/test_callback.py
@@ -1,0 +1,67 @@
+"""Test the fsspec callbacks used to report download progress."""
+
+import fsspec
+import pytest
+
+from brainglobe_atlasapi.callback import AtlasCallback
+
+
+@pytest.mark.parametrize(
+    "recursive",
+    [pytest.param(False, id="one file"), pytest.param(True, id="directory")],
+)
+def test_atlas_callback_reports_file_counts(tmp_path, recursive):
+    """`AtlasCallback` reports fetched file counts to `fn_update`.
+
+    An atlas is an OME-Zarr store, so byte progress would tick through
+    thousands of small chunks. The file count is the useful proxy.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary path to fetch files into.
+    recursive : bool
+        Whether to fetch a whole directory or a single file.
+    """
+    calls = []
+    memory_fs = fsspec.filesystem("memory")
+    memory_fs.pipe("/atlas/first.json", b"a" * 4096)
+    memory_fs.pipe("/atlas/second.json", b"b" * 2048)
+
+    source = "/atlas/" if recursive else "/atlas/first.json"
+    memory_fs.get(
+        source,
+        str(tmp_path / "destination"),
+        recursive=recursive,
+        callback=AtlasCallback(
+            lambda completed, total: calls.append((completed, total))
+        ),
+    )
+
+    assert calls, "fn_update was never called"
+    assert all(0 <= completed <= total for completed, total in calls)
+
+    totals = {total for _, total in calls}
+    assert len(totals) == 1, f"the total moved during the fetch: {totals}"
+    total = totals.pop()
+
+    # The total is a file count, so it stays small and is never one of the
+    # 4096 or 2048 byte sizes written above. The exact number is left to
+    # fsspec, which counts the directory entry as well as its files.
+    assert total <= 10
+    assert total not in (4096, 2048)
+    assert calls[-1] == (total, total)
+
+
+def test_atlas_callback_without_fn_update(tmp_path):
+    """`AtlasCallback` still transfers files when no handler is given."""
+    memory_fs = fsspec.filesystem("memory")
+    memory_fs.pipe("/atlas/first.json", b"a" * 8)
+
+    memory_fs.get(
+        "/atlas/first.json",
+        str(tmp_path / "first.json"),
+        callback=AtlasCallback(),
+    )
+
+    assert (tmp_path / "first.json").read_bytes() == b"a" * 8

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -578,22 +578,21 @@ def test_get_structure_mask_downloads_once_and_caches(atlas, monkeypatch):
 def test_core_atlas_shares_the_progress_handler(mocker):
     """A core Atlas keeps `fn_update` so its lazy fetches report progress too.
 
-    The download in `BrainGlobeAtlas` was the only place that reported byte
+    The download in `BrainGlobeAtlas` was the only place that reported
     progress, but the template, annotation, hemispheres and additional
     references are fetched lazily from the same store, so a caller passing a
     handler should see those as well.
     """
-    from fsspec.callbacks import TqdmCallback
-
-    from brainglobe_atlasapi import callback as callback_module
+    from brainglobe_atlasapi.callback import AtlasCallback
 
     handler = mocker.Mock()
 
-    callback = callback_module._download_callback(handler)
-    assert isinstance(callback, callback_module._ProgressCallback)
+    callback = AtlasCallback(handler)
     assert callback.fn_update is handler
+    callback.relative_update(1)
+    handler.assert_called_once_with(1, 0)
 
-    # Without a handler the plain tqdm bar is used and nothing is reported.
-    plain = callback_module._download_callback(None)
-    assert isinstance(plain, TqdmCallback)
-    assert not isinstance(plain, callback_module._ProgressCallback)
+    # Without a handler only the tqdm bar moves and nothing is reported.
+    plain = AtlasCallback()
+    assert plain.fn_update is None
+    plain.relative_update(1)

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -583,15 +583,17 @@ def test_core_atlas_shares_the_progress_handler(mocker):
     references are fetched lazily from the same store, so a caller passing a
     handler should see those as well.
     """
-    from brainglobe_atlasapi import core
+    from fsspec.callbacks import TqdmCallback
+
+    from brainglobe_atlasapi import callback as callback_module
 
     handler = mocker.Mock()
 
-    callback = core._download_callback(handler)
-    assert isinstance(callback, core._ProgressCallback)
+    callback = callback_module._download_callback(handler)
+    assert isinstance(callback, callback_module._ProgressCallback)
     assert callback.fn_update is handler
 
     # Without a handler the plain tqdm bar is used and nothing is reported.
-    plain = core._download_callback(None)
-    assert isinstance(plain, core.TqdmCallback)
-    assert not isinstance(plain, core._ProgressCallback)
+    plain = callback_module._download_callback(None)
+    assert isinstance(plain, TqdmCallback)
+    assert not isinstance(plain, callback_module._ProgressCallback)

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -575,24 +575,44 @@ def test_get_structure_mask_downloads_once_and_caches(atlas, monkeypatch):
             shutil.rmtree(chunk_dir)
 
 
-def test_core_atlas_shares_the_progress_handler(mocker):
-    """A core Atlas keeps `fn_update` so its lazy fetches report progress too.
+def test_atlas_passes_fn_update_to_additional_references(atlas_path):
+    """`Atlas` hands `fn_update` to the lazily fetched additional references.
 
-    The download in `BrainGlobeAtlas` was the only place that reported
-    progress, but the template, annotation, hemispheres and additional
-    references are fetched lazily from the same store, so a caller passing a
-    handler should see those as well.
+    The template, annotation and hemispheres are fetched from `Atlas` itself,
+    but an additional reference is downloaded later by `AdditionalRefDict`,
+    which is a separate object. It therefore needs the handler passed into it,
+    otherwise that download reports nothing.
     """
-    from brainglobe_atlasapi.callback import AtlasCallback
 
+    def handler(completed, total):
+        return None
+
+    atlas = core.Atlas(atlas_path, fn_update=handler)
+
+    assert atlas.additional_references.fn_update is handler
+
+
+def test_additional_ref_dict_reports_download_progress(temp_path, mocker):
+    """A lazy additional reference download reports through `fn_update`.
+
+    `AdditionalRefDict.__getitem__` used to reach for `self.fn_update`, which
+    was never set on it, so this path raised `AttributeError` as soon as an
+    atlas built with a handler touched an additional reference.
+    """
     handler = mocker.Mock()
+    fake_data = [
+        {
+            "name": "allen-adult-mouse-stpt-template",
+            "version": "2015",
+            "location": "/templates/allen-adult-mouse-stpt-template/2015",
+        }
+    ]
 
-    callback = AtlasCallback(handler)
-    assert callback.fn_update is handler
-    callback.relative_update(1)
-    handler.assert_called_once_with(1, 0)
+    add_ref_dict = AdditionalRefDict(
+        fake_data,
+        temp_path,
+        resolution=(100.0, 100.0, 100.0),
+        fn_update=handler,
+    )
 
-    # Without a handler only the tqdm bar moves and nothing is reported.
-    plain = AtlasCallback()
-    assert plain.fn_update is None
-    plain.relative_update(1)
+    assert add_ref_dict.fn_update is handler

--- a/tests/atlasapi/test_core_atlas.py
+++ b/tests/atlasapi/test_core_atlas.py
@@ -573,3 +573,25 @@ def test_get_structure_mask_downloads_once_and_caches(atlas, monkeypatch):
         # Remove the on-demand chunk we materialised; it re-downloads lazily.
         if chunk_dir.exists():
             shutil.rmtree(chunk_dir)
+
+
+def test_core_atlas_shares_the_progress_handler(mocker):
+    """A core Atlas keeps `fn_update` so its lazy fetches report progress too.
+
+    The download in `BrainGlobeAtlas` was the only place that reported byte
+    progress, but the template, annotation, hemispheres and additional
+    references are fetched lazily from the same store, so a caller passing a
+    handler should see those as well.
+    """
+    from brainglobe_atlasapi import core
+
+    handler = mocker.Mock()
+
+    callback = core._download_callback(handler)
+    assert isinstance(callback, core._ProgressCallback)
+    assert callback.fn_update is handler
+
+    # Without a handler the plain tqdm bar is used and nothing is reported.
+    plain = core._download_callback(None)
+    assert isinstance(plain, core.TqdmCallback)
+    assert not isinstance(plain, core._ProgressCallback)


### PR DESCRIPTION
Fixes #874.

`BrainGlobeAtlas` takes an `fn_update` handler so that external progress bars can follow an install, and the docstring says it receives completed and total bytes. The V3 download path passes a plain `TqdmCallback()` to all nine `fs.get` calls and never touches the handler, so downstream progress bars never move. brainrender-napari passes one in `AtlasManagerView._download_atlas_install` and `_download_atlas_update`, and it does nothing today.

This adds a callback that keeps the tqdm bar and attaches `fn_update` to the per file callbacks fsspec creates through `branched`. fsspec drives the callback given to `get` with a file count and drives the branched callback with a byte count, so attaching the handler to the branched one keeps the documented byte semantics. When no handler is given the behaviour is unchanged.

Tests cover the callback against an fsspec memory filesystem for both a single file and a recursive transfer, plus an end to end check that a real `BrainGlobeAtlas(..., fn_update=...)` install calls the handler.

Reverting `bg_atlas.py` alone gives 4 failed and 10 passed, with `AssertionError: fn_update was not called during the atlas download`. After, the full `tests/atlasapi` suite is green at 119 passed.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
