### PR TITLE
List locally installed custom atlases

### DIFF
--- a/brainglobe_atlasapi/list_atlases.py
+++ b/brainglobe_atlasapi/list_atlases.py
@@ -80,6 +80,27 @@ def get_local_atlas_version(atlas_name: str) -> Optional[str]:
         return None
 
 
+def get_custom_atlases() -> Dict[str, Any]:
+    """Read the versions of the locally registered custom atlases.
+
+    Returns
+    -------
+    dict
+        A mapping from custom atlas name to version. Empty if no custom
+        atlases have been registered.
+    """
+    custom_path = (
+        config.get_brainglobe_dir()
+        / "brainglobe-atlasapi"
+        / descriptors.V3_ATLAS_ROOTDIR
+        / "custom_atlases.conf"
+    )
+    try:
+        return dict(utils.conf_from_file(custom_path)["atlases"])
+    except (FileNotFoundError, KeyError):
+        return {}
+
+
 def get_all_atlases_lastversions() -> Dict[str, Any]:
     """Read from URL or local cache all available last versions."""
     v2_dir = descriptors.V3_ATLAS_ROOTDIR
@@ -88,12 +109,6 @@ def get_all_atlases_lastversions() -> Dict[str, Any]:
         / "brainglobe-atlasapi"
         / v2_dir
         / "last_versions.conf"
-    )
-    custom_path = (
-        config.get_brainglobe_dir()
-        / "brainglobe-atlasapi"
-        / v2_dir
-        / "custom_atlases.conf"
     )
 
     if utils.check_internet_connection(raise_error=False):
@@ -106,11 +121,8 @@ def get_all_atlases_lastversions() -> Dict[str, Any]:
     else:
         print("Cannot fetch latest atlas versions from the server.")
         official_atlases = utils.conf_from_file(cache_path)
-    try:
-        custom_atlases = utils.conf_from_file(custom_path)
-        return {**official_atlases["atlases"], **custom_atlases["atlases"]}
-    except (FileNotFoundError, KeyError):
-        return dict(official_atlases["atlases"])
+
+    return {**official_atlases["atlases"], **get_custom_atlases()}
 
 
 def get_atlases_lastversions() -> Dict[str, Dict[str, Any]]:
@@ -123,23 +135,30 @@ def get_atlases_lastversions() -> Dict[str, Dict[str, Any]]:
     dict
         A dictionary with metadata about already installed atlases. The
         ``version`` and ``latest_version`` fields use the same dotted form
-        (e.g. ``3.0``), matching ``last_versions.conf``.
+        (e.g. ``3.0``), matching ``last_versions.conf``. Atlases installed by
+        the user rather than distributed by BrainGlobe are flagged with
+        ``custom=True``. A custom atlas that is not registered in
+        ``custom_atlases.conf`` has no version to compare against, so its
+        ``latest_version`` is empty and ``updated`` is None.
     """
     available_atlases = get_all_atlases_lastversions()
+    custom_atlases = get_custom_atlases()
 
     # Get downloaded atlases looping over folders in brainglobe directory:
     atlases = {}
     for name in get_downloaded_atlases():
-        if name in available_atlases.keys():
-            local_version = get_local_atlas_version(name)
-            latest = str(available_atlases[name])
-            atlases[name] = dict(
-                downloaded=True,
-                local=name,
-                version=local_version,
-                latest_version=latest,
-                updated=local_version == latest,
-            )
+        local_version = get_local_atlas_version(name)
+        latest = (
+            str(available_atlases[name]) if name in available_atlases else ""
+        )
+        atlases[name] = dict(
+            downloaded=True,
+            local=name,
+            version=local_version,
+            latest_version=latest,
+            updated=local_version == latest if latest else None,
+            custom=name in custom_atlases or name not in available_atlases,
+        )
     return atlases
 
 
@@ -176,6 +195,7 @@ def show_atlases(show_local_path: bool = False, table_width: int = 88) -> None:
                 version="",
                 latest_version=str(available_atlases[atlas]),
                 updated=None,
+                custom=False,
             )
 
     # Create table
@@ -189,6 +209,7 @@ def show_atlases(show_local_path: bool = False, table_width: int = 88) -> None:
 
     table.add_column("Name", no_wrap=True, width=32)
     table.add_column("Downloaded", justify="center")
+    table.add_column("Custom", justify="center")
     table.add_column("Updated", justify="center")
     table.add_column("Local version", justify="center")
     table.add_column("Latest version", justify="center")
@@ -250,7 +271,10 @@ def add_atlas_to_row(
     if info["downloaded"]:
         downloaded = "[green]:heavy_check_mark:[/green]"
 
-        if info["updated"]:
+        if info["updated"] is None:
+            # No known remote version to compare the local files against.
+            updated = ""
+        elif info["updated"]:
             updated = "[green]:heavy_check_mark:[/green]"
         else:
             updated = "[red dim]x"
@@ -259,9 +283,12 @@ def add_atlas_to_row(
         downloaded = ""
         updated = ""
 
+    custom = "[green]:heavy_check_mark:[/green]" if info.get("custom") else ""
+
     row = [
         "[bold]" + atlas,
         downloaded,
+        custom,
         updated,
         (
             "[#c4c4c4]" + info["version"]

--- a/brainglobe_atlasapi/list_atlases.py
+++ b/brainglobe_atlasapi/list_atlases.py
@@ -11,6 +11,9 @@ from rich.table import Table
 
 from brainglobe_atlasapi import config, descriptors, utils
 
+# Rich markup for the tick shown in the atlas table for a boolean "yes".
+CHECK_MARK = "[green]:heavy_check_mark:[/green]"
+
 
 def folder_version_to_dotted(version: Optional[str]) -> Optional[str]:
     """Convert on-disk version folder names (e.g. 3_0) to dotted form (3.0)."""
@@ -269,13 +272,13 @@ def add_atlas_to_row(
 
     """
     if info["downloaded"]:
-        downloaded = "[green]:heavy_check_mark:[/green]"
+        downloaded = CHECK_MARK
 
         if info["updated"] is None:
             # No known remote version to compare the local files against.
             updated = ""
         elif info["updated"]:
-            updated = "[green]:heavy_check_mark:[/green]"
+            updated = CHECK_MARK
         else:
             updated = "[red dim]x"
 
@@ -283,7 +286,7 @@ def add_atlas_to_row(
         downloaded = ""
         updated = ""
 
-    custom = "[green]:heavy_check_mark:[/green]" if info.get("custom") else ""
+    custom = CHECK_MARK if info.get("custom") else ""
 
     row = [
         "[bold]" + atlas,

--- a/tests/atlasapi/test_list_atlases.py
+++ b/tests/atlasapi/test_list_atlases.py
@@ -20,6 +20,45 @@ from brainglobe_atlasapi.list_atlases import (
 )
 
 
+@pytest.fixture
+def mock_installed_atlases(mocker):
+    """Pretend one official and one custom atlas are installed locally.
+
+    Parameters
+    ----------
+    mocker : pytest_mock.plugin.MockerFixture
+        The mocker fixture.
+
+    Returns
+    -------
+    Callable
+        Call with the contents of ``custom_atlases.conf`` to apply the mocks.
+    """
+
+    def _apply(registered_custom):
+        official = {"example_mouse_100um": "3.0"}
+        mocker.patch(
+            "brainglobe_atlasapi.list_atlases.get_downloaded_atlases",
+            return_value=["example_mouse_100um", "my_custom_atlas_10um"],
+        )
+        mocker.patch(
+            "brainglobe_atlasapi.list_atlases.get_all_atlases_lastversions",
+            return_value={**official, **registered_custom},
+        )
+        mocker.patch(
+            "brainglobe_atlasapi.list_atlases.get_custom_atlases",
+            return_value=registered_custom,
+        )
+        mocker.patch(
+            "brainglobe_atlasapi.list_atlases.get_local_atlas_version",
+            side_effect=lambda name: (
+                "3.0" if name == "example_mouse_100um" else "1.0"
+            ),
+        )
+
+    return _apply
+
+
 def test_folder_version_to_dotted():
     """Test conversion from folder-style version to dotted version."""
     assert folder_version_to_dotted("3_0") == "3.0"
@@ -82,6 +121,73 @@ def test_show_atlases():
     """Test displaying a table of available atlases."""
     # TODO add more valid testing than just look for errors when running:
     show_atlases(show_local_path=True)
+
+
+def test_lastversions_unregistered_custom_atlas(mock_installed_atlases):
+    """A locally installed atlas absent from both conf files is listed.
+
+    Parameters
+    ----------
+    mock_installed_atlases : Callable
+        Fixture mocking the set of installed atlases.
+    """
+    mock_installed_atlases({})
+
+    atlases = get_atlases_lastversions()
+
+    assert "my_custom_atlas_10um" in atlases
+    custom = atlases["my_custom_atlas_10um"]
+    assert custom["custom"] is True
+    assert custom["downloaded"] is True
+    assert custom["version"] == "1.0"
+    # There is no known remote version to compare the local files against.
+    assert custom["latest_version"] == ""
+    assert custom["updated"] is None
+
+    official = atlases["example_mouse_100um"]
+    assert official["custom"] is False
+    assert official["latest_version"] == "3.0"
+    assert official["updated"] is True
+
+
+def test_lastversions_registered_custom_atlas(mock_installed_atlases):
+    """An atlas in custom_atlases.conf is listed and flagged as custom.
+
+    Parameters
+    ----------
+    mock_installed_atlases : Callable
+        Fixture mocking the set of installed atlases.
+    """
+    mock_installed_atlases({"my_custom_atlas_10um": "1.0"})
+
+    atlases = get_atlases_lastversions()
+
+    custom = atlases["my_custom_atlas_10um"]
+    assert custom["custom"] is True
+    assert custom["latest_version"] == "1.0"
+    assert custom["updated"] is True
+    assert atlases["example_mouse_100um"]["custom"] is False
+
+
+def test_show_atlases_lists_custom_atlas(mock_installed_atlases, capsys):
+    """Custom atlases appear in the printed table.
+
+    Parameters
+    ----------
+    mock_installed_atlases : Callable
+        Fixture mocking the set of installed atlases.
+    capsys : pytest.CaptureFixture
+        Fixture to capture stdout/stderr.
+    """
+    mock_installed_atlases({})
+
+    show_atlases()
+
+    # The "Custom" column is dropped by rich on narrow terminals, so only
+    # the name is checked here. The marker itself is covered by
+    # `test_add_atlas_to_row`.
+    captured = capsys.readouterr()
+    assert "my_custom_atlas_10um" in captured.out
 
 
 def test_get_all_atlases_lastversions():
@@ -229,8 +335,9 @@ def test_get_all_atlases_lastversions_gin_down():
                 "version": "1",
                 "latest_version": "2",
                 "updated": False,
+                "custom": False,
             },
-            "│ awesome_name │ ✔ │ x │ 1 │ 2 │",
+            "│ awesome_name │ ✔ │  │ x │ 1 │ 2 │",
             id="version != latest_version",
         ),
         pytest.param(
@@ -238,9 +345,20 @@ def test_get_all_atlases_lastversions_gin_down():
                 "version": "1",
                 "latest_version": "1",
                 "updated": True,
+                "custom": False,
             },
-            "│ awesome_name │ ✔ │ ✔ │ 1 │ 1 │",
+            "│ awesome_name │ ✔ │  │ ✔ │ 1 │ 1 │",
             id="version == latest_version",
+        ),
+        pytest.param(
+            {
+                "version": "1",
+                "latest_version": "",
+                "updated": None,
+                "custom": True,
+            },
+            "│ awesome_name │ ✔ │ ✔ │  │ 1 │  │",
+            id="custom atlas without a remote version",
         ),
     ],
 )
@@ -261,6 +379,7 @@ def test_add_atlas_to_row(version, expected_print, capsys):
         "version": version["version"],
         "latest_version": version["latest_version"],
         "updated": version["updated"],
+        "custom": version["custom"],
     }
     table = add_atlas_to_row(atlas="awesome_name", info=info, table=Table())
     Console().print(table)


### PR DESCRIPTION
Fixes #906.

`get_atlases_lastversions` only kept a downloaded atlas if its name also appeared in `last_versions.conf` or `custom_atlases.conf`. Nothing in this repo writes `custom_atlases.conf`, so an atlas a user installed themselves has files on disk but no conf entry, and is silently dropped from `brainglobe list`.

Every downloaded atlas is now included. User installed ones carry a new `custom` key and get a `Custom` column in the table. A custom atlas with no registered version has nothing to compare against, so its latest version stays empty and `updated` is `None` rather than a red cross claiming it is out of date. The custom conf read moved into a small `get_custom_atlases` helper so the two call sites share it.

Reverting `list_atlases.py` alone gives 6 failed and 12 passed, including a `KeyError` where the custom atlas is missing from the result entirely, and a table assertion showing the old output rendering a red cross in the updated column. After, the full `tests/atlasapi` suite is green at 119 passed, verified at `COLUMNS` of 40, 80 and 200 so the table renders correctly at different widths.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
