### PR TITLE
reorient asymetric hemispheres during packaging

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
@@ -454,9 +454,12 @@ class AtlasPackagingData:
             self.additional_references[i] = (stack_tuple[0], ref_stack)
 
         self.symmetric = self.hemispheres_stack is None
-
+        
         if not self.symmetric:
             self.hemispheres_stack = _load_stack(self.hemispheres_stack)
+            self.hemispheres_stack = _reorient_stacks(
+                    self.hemispheres_stack, self.space_convention
+                )
         else:
             self.hemispheres_stack = _auto_generate_hemispheres(
                 shapes=[stack.shape for stack in self.annotation_stack],

--- a/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
@@ -454,12 +454,12 @@ class AtlasPackagingData:
             self.additional_references[i] = (stack_tuple[0], ref_stack)
 
         self.symmetric = self.hemispheres_stack is None
-        
+
         if not self.symmetric:
             self.hemispheres_stack = _load_stack(self.hemispheres_stack)
             self.hemispheres_stack = _reorient_stacks(
-                    self.hemispheres_stack, self.space_convention
-                )
+                self.hemispheres_stack, self.space_convention
+            )
         else:
             self.hemispheres_stack = _auto_generate_hemispheres(
                 shapes=[stack.shape for stack in self.annotation_stack],


### PR DESCRIPTION

## Description
We now reorient asymetric hemisphere masks during atlas packaging. 

- [x] Bug fix

**Why is this PR needed?**

Previously asymmetric hemisphere masks were not being reoriented. 

## References

closes #918 

## How has this PR been tested?

I packaged the duke mouse atlas and validated the hemispheres were now in the correct orientation. 



## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
