### PR TITLE
Update remote URL to use atlas not atlas-rc2

### DIFF
--- a/brainglobe_atlasapi/descriptors.py
+++ b/brainglobe_atlasapi/descriptors.py
@@ -8,10 +8,8 @@ import numpy.typing as npt
 
 # Base url of the gin repository:
 remote_url_base = "https://gin.g-node.org/brainglobe/atlases/raw/master/{}"
-remote_url_s3 = "s3://brainglobe/atlas-rc2/{}"
-remote_url_s3_http = (
-    "https://brainglobe.s3.us-west-2.amazonaws.com/atlas-rc2/{}"
-)
+remote_url_s3 = "s3://brainglobe/atlas/{}"
+remote_url_s3_http = "https://brainglobe.s3.us-west-2.amazonaws.com/atlas/{}"
 
 # Major version of atlases used by current brainglobe-atlasapi release:
 ATLAS_MAJOR_V = 0


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
See #885 

**What does this PR do?**
Changes the remote S3 path from `atlas-rc2` to `atlas`

## References
Closes #885 

## How has this PR been tested?
All existing tests pass locally. Deleted local `.brainglobe/brainglobe-atlasapi` directory and fetched test atlases from `s3://brainglobe/atlas`.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
