### PR TITLE
Pin aiobotocore for downstream env resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+    "aiobotocore >= 3.6.0",
     "brainglobe-space >= 1.0.0",
     "click",
     "DracoPy",
@@ -67,7 +68,7 @@ kocher_bumblebee = ["vtk"]
 
 atlasgen = [
     "brainglobe-utils",
-    "cloud-volume",
+    "cloud-volume>=12",
     "loguru",
     "numba",
     "ome-zarr<0.17.0",


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
`pip` dependency resolution got stuck in a loop working backward through compatible version of `botocore` and `aiobotocore`. This gives it a floor to work with to allow resolution to succeed.

Also addresses a similar issue with `cloud-volume` see https://github.com/brainglobe/brainrender/pull/467.

**What does this PR do?**
Pins `aiobotocore>=3.6.0`.
Pins `cloud-volume>=12`.

## How has this PR been tested?
Tested by locally building an environment with `pip` with or without the pin. All tests pass with the pin.

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
