### PR TITLE
Raises the ngff-zarr lower pin and declares dask for atlasgen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "DracoPy",
     "fsspec",
     "meshio",
-    "ngff-zarr>=0.37.0",
+    "ngff-zarr>=0.39.0",
     "numpy<2.5",
     "pandas",
     "pyarrow",
@@ -70,6 +70,7 @@ kocher_bumblebee = ["vtk"]
 atlasgen = [
     "brainglobe-utils",
     "cloud-volume>=12",
+    "dask[array]>=2026.1.2",
     "loguru",
     "numba",
     "ome-zarr<0.17.0",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Closes #935.

The free variable is the `ngff-zarr` floor rather than the `dask` version. `ngff-zarr>=0.37.0`,
set in #930 a few hours before #935 was filed, admits 0.37.0, 0.37.1 and 0.38.0, and the
requirement those three declare is:

    dask[array]!=2025.12.0,!=2026.1.0,!=2026.1.1

Three exclusions and **no lower bound**. `dask[array]>=2026.1.2` first appears in ngff-zarr
**0.39.0** (2026-07-17).

Measured against this repository's own `pyproject.toml` at `241d1d3`, adding one constraint and
changing nothing else:

    uv pip compile --python-version 3.11 --constraint <(echo 'dask==2024.8.1') pyproject.toml
    dask==2024.8.1
    ngff-zarr==0.38.0
    zarr==3.1.6

That is the environment in the downstream report. Each step of it is in the shipped code:

* ngff-zarr 0.38.0, `ngff_zarr/v04/zarr_metadata.py:543` --
  `data = dask.array.from_zarr(store, component=dataset_path)`
* dask 2024.8.1, `dask/array/core.py`, `from_zarr` --
  `z = zarr.Array(store, read_only=True, path=component, **kwargs)`
* zarr 3.1.6, `Array.__init__(self, metadata, store_path, config)` -- no `read_only` parameter

which is the reported `TypeError: Array.__init__() got an unexpected keyword argument
'read_only'`. On Python 3.13 the same compile selects `zarr==3.3.0` and the result is the same.

**What does this PR do?**

1. `ngff-zarr>=0.37.0` -> `>=0.39.0`. This is the hunk that closes #935, and it is on the
   path where the failure happens: `brainglobe_atlasapi/core.py` imports `ngff_zarr` and is reached by a plain
   install, with no extra. 0.39.0 is the release where upstream added the dask floor, so this
   defers the dask/zarr compatibility contract to the library that owns it instead of keeping a
   second copy of it here that would need moving again when upstream moves theirs.

2. Adds `dask[array]>=2026.1.2` to `atlasgen`. `brainglobe_atlasapi/atlas_generation/wrapup.py:9` and `tests/atlasgen/test_stacks.py:6` both
   `import dask.array as da`, and `dask` appears nowhere in `pyproject.toml` -- today it arrives
   only as `ngff-zarr`'s transitive dependency. **This hunk does not fix #935**: an extra is
   not installed on the reporting user's path. It declares a direct import, and it keeps the
   floor true if `ngff-zarr`'s own constraint changes.

Either hunk alone makes the resolution above impossible. Both are here because they answer
different questions.

## References

* Closes #935
* AntonioST/NeuroCarto#2 -- the downstream report and traceback
* #930 set the current `>=0.37.0`
* #860 (`s3fs`) and #922 (`aiobotocore`, `cloud-volume`) are the same shape

## How has this PR been tested?

`uv pip compile` against this repository's `pyproject.toml`, before and after the change:

| | result |
|---|---|
| before, `--constraint dask==2024.8.1`, py3.11 | resolves: `ngff-zarr==0.38.0`, `dask==2024.8.1`, `zarr==3.1.6` |
| before, same constraint, py3.13 | resolves: `ngff-zarr==0.38.0`, `dask==2024.8.1`, `zarr==3.3.0` |
| after, same constraint, either | `No solution found ... ngff-zarr>=0.39.0 depends on dask[array]>=2026.1.2 and dask==2024.8.1` |
| after, unconstrained, py3.11 | `ngff-zarr==0.42.1`, `dask==2026.7.1`, `zarr==3.1.6` |
| after, unconstrained, py3.13 | `ngff-zarr==0.42.1`, `dask==2026.7.1`, `zarr==3.3.0` |

**The unconstrained resolution does not move.** A fresh compile on py3.11 produces a
byte-identical 181-package lock before and after this change, and the same holds with
`--extra atlasgen`. The change removes a region the manifest permitted; it does not change what
an unconstrained install gets, which is also why CI -- having no upper bound on `ngff-zarr` --
has been exercising only the versions this PR keeps.

No test is added: the change is manifest metadata, and the resolution above is its test.

## Is this a breaking change?

Only for an environment that needs `ngff-zarr` 0.37.0-0.38.0 alongside this package. Those three
releases have never been exercised in CI, since there is no upper bound.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

## Noticed while measuring, not changed here

#935 refers to corner cases where resolution "backtracked to very old versions of certain
dependencies", and that is broader than `dask`. Eight entries in `dependencies` carry no lower
bound at all, and `numpy<2.5` carries only an upper one, so the oldest release the manifest
permits is in several cases the first one ever published:

| requirement | oldest permitted | released |
|---|---|---|
| `click` | 0.1 | 2014-04-28 |
| `DracoPy` | 0.0.0 | 2019-03-06 |
| `fsspec` | 0.1.0 | 2019-01-02 |
| `meshio` | 0.1.0 | 2015-11-10 |
| `pandas` | 0.1 | 2009-12-25 |
| `pyarrow` | 0.2.0 | 2017-03-16 |
| `requests` | 0.2.0 | 2011-02-14 |
| `treelib` | 1.2 | 2013-04-28 |
| `numpy<2.5` | 1.0 | 2006-12-02 |

`uv pip compile --resolution lowest-direct` -- not what a normal install does, but it measures
what the manifest permits -- stops on `dracopy==0.0.0`, whose `setup.py` imports
`packaging.version.LegacyVersion` (removed in packaging 22) and cannot build on 3.11; with
`DracoPy` removed from the probe it stops next on `meshio==0.1.0` (2015), which imports `h5py`
at build time.

None of those are touched here. Floors are a judgement about what a project is willing to
support, and this diff has one purpose. Recording the measurement so it is not lost.
