### PR TITLE
Add validation for whitespace in structure acronyms

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -505,6 +505,45 @@ def validate_unique_acronyms(atlas: BrainGlobeAtlas):
     return True
 
 
+def validate_acronym_whitespace(atlas: BrainGlobeAtlas):
+    """Validate that no structure acronym has leading or trailing whitespace.
+
+    Acronyms are used as a primary key to fetch details for a region, so
+    an acronym padded with whitespace is hard to look up and easy to
+    mistake for its stripped counterpart.
+
+    Parameters
+    ----------
+    atlas : BrainGlobeAtlas
+        The BrainGlobeAtlas object to validate.
+
+    Returns
+    -------
+    bool
+        True if no acronym has leading or trailing whitespace.
+
+    Raises
+    ------
+    AssertionError
+        If any acronym in the atlas structures has leading or trailing
+        whitespace.
+    """
+    padded = []
+
+    for structure in atlas.structures:
+        acronym = atlas.structures[structure]["acronym"]
+        if acronym != acronym.strip():
+            name = atlas.structures[structure]["name"]
+            # repr the acronym, otherwise the whitespace is invisible
+            padded.append(f"{acronym!r} ({name})")
+
+    assert len(padded) == 0, (
+        "Acronyms with leading or trailing whitespace found in atlas "
+        f"structures: {', '.join(sorted(padded))}"
+    )
+    return True
+
+
 def validate_atlas_name(atlas: BrainGlobeAtlas):
     """Validate the naming convention of the atlas.
 
@@ -662,6 +701,7 @@ def get_all_validation_functions():
         validate_template_image_pixels,
         validate_annotation_symmetry,
         validate_unique_acronyms,
+        validate_acronym_whitespace,
         validate_atlas_name,
         validate_atlas_name_listed,
     ]

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -13,6 +13,7 @@ from brainglobe_atlasapi.atlas_generation.validate_atlases import (
     catch_missing_mesh_files,
     catch_missing_structures,
     get_all_validation_functions,
+    validate_acronym_whitespace,
     validate_additional_references,
     validate_annotation_symmetry,
     validate_atlas_files,
@@ -551,3 +552,52 @@ def test_validate_unique_acronyms_fail(mocker, atlas):
     error_message = str(exc_info.value)
     assert "brain" in error_message
     assert "Brain Duplicate" in error_message
+
+
+def test_validate_acronym_whitespace_pass(mocker, atlas):
+    """Check that an atlas with tidy acronyms passes validation.
+
+    Parameters
+    ----------
+    mocker : pytest_mock.MockerFixture
+        Mocker fixture for patching.
+    atlas : BrainGlobeAtlas
+        A BrainGlobeAtlas instance.
+    """
+    tidy_structures = {
+        1: {"acronym": "root", "name": "Root"},
+        2: {"acronym": "brain", "name": "Brain"},
+        3: {"acronym": "cortex", "name": "Cortex"},
+    }
+    mocker.patch.object(atlas, "structures", tidy_structures)
+
+    assert validate_acronym_whitespace(atlas)
+
+
+def test_validate_acronym_whitespace_fail(mocker, atlas):
+    """Check that acronyms padded with whitespace fail validation.
+
+    Parameters
+    ----------
+    mocker : pytest_mock.MockerFixture
+        Mocker fixture for patching.
+    atlas : BrainGlobeAtlas
+        A BrainGlobeAtlas instance.
+    """
+    structures_with_whitespace = {
+        1: {"acronym": "root", "name": "Root"},
+        2: {"acronym": "brain ", "name": "Brain Trailing"},  # Trailing space!
+        3: {"acronym": "\tcortex", "name": "Cortex Leading"},  # Leading tab!
+    }
+    mocker.patch.object(atlas, "structures", structures_with_whitespace)
+
+    with pytest.raises(AssertionError) as exc_info:
+        validate_acronym_whitespace(atlas)
+
+    # The whitespace is only visible in the error message if the acronym
+    # is repr'd, so check for the quoted forms
+    error_message = str(exc_info.value)
+    assert "'brain '" in error_message
+    assert "Brain Trailing" in error_message
+    assert "'\\tcortex'" in error_message
+    assert "Cortex Leading" in error_message


### PR DESCRIPTION
Closes #876.

Structure acronyms are the key used to look up a region, so an acronym like `"VS "` is easy to create by accident and painful to use afterwards. Nothing in the packaging checks caught it, and the padding is invisible in most output, so it only turns up later when a lookup quietly fails.

This adds `validate_acronym_whitespace`, modelled on the existing `validate_unique_acronyms`. It walks `atlas.structures`, collects any acronym where `acronym != acronym.strip()`, and fails with the offenders passed through `repr` so the space or tab is actually visible in the message. It is registered in `get_all_validation_functions`, so it runs during `wrapup_atlas_from_data`.

Tests cover a passing case and a failing case with both a trailing space and a leading tab, using the same mocker pattern as the duplicate acronym test. `pytest tests/atlasgen/test_validation.py` passes locally: 22 passed, 5 xfailed, the same xfails as on main.

I used Claude Code to help write this.