### PR TITLE
Fail early when annotation labels do not fit in uint32

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
+++ b/brainglobe_atlasapi/atlas_generation/atlas_packaging_data.py
@@ -432,6 +432,7 @@ class AtlasPackagingData:
         self.resolution = _standardize_resolution(self.resolution)
         self.reference_stack = _load_stack(self.reference_stack)
         self.annotation_stack = _load_stack(self.annotation_stack)
+        _check_annotation_dtype(self.annotation_stack)
 
         shape = self.reference_stack[0].shape
         volume_shape = tuple(
@@ -530,6 +531,51 @@ def _load_stack(
         "Invalid stack format. Each item in the list must be a "
         "file path or a numpy array."
     )
+
+
+def _check_annotation_dtype(stacks: List[npt.NDArray]) -> None:
+    """Check that every annotation scale holds valid uint32 labels.
+
+    Annotations are written, and looked up during mask generation, as
+    `descriptors.ANNOTATION_DTYPE`. A stack that cannot be converted without
+    loss (a float stack, or an integer stack with values outside the uint32
+    range) otherwise fails much later with a cryptic numba typing error, or
+    is silently wrapped around.
+
+    Parameters
+    ----------
+    stacks : List[np.ndarray]
+        The loaded annotation stack, one array per scale level.
+
+    Raises
+    ------
+    ValueError
+        If any scale level cannot be cast to `descriptors.ANNOTATION_DTYPE`
+        without loss.
+    """
+    limits = np.iinfo(descriptors.ANNOTATION_DTYPE)
+
+    for stack in stacks:
+        if np.can_cast(
+            stack.dtype, descriptors.ANNOTATION_DTYPE, casting="safe"
+        ):
+            continue
+
+        values_fit = np.issubdtype(stack.dtype, np.integer) and (
+            stack.size == 0
+            or (stack.min() >= limits.min and stack.max() <= limits.max)
+        )
+        if values_fit:
+            continue
+
+        raise ValueError(
+            f"Annotation stack has dtype {stack.dtype}. BrainGlobe "
+            f"annotations must be integer labels between {limits.min} and "
+            f"{limits.max}, so they can be stored as "
+            f"{np.dtype(descriptors.ANNOTATION_DTYPE).name}. Cast them "
+            "explicitly, e.g. annotation = annotation.astype(np.uint32), "
+            "before calling wrapup_atlas_from_data."
+        )
 
 
 def _reorient_stacks(

--- a/tests/atlasgen/test_atlas_packaging_data.py
+++ b/tests/atlasgen/test_atlas_packaging_data.py
@@ -19,6 +19,7 @@ from brainglobe_atlasapi.atlas_generation.atlas_packaging_data import (
     TemplateInfo,
     TerminologyInfo,
     _auto_generate_hemispheres,
+    _check_annotation_dtype,
     _load_stack,
     _reorient_stacks,
     _standardize_resolution,
@@ -171,6 +172,51 @@ def test_reorient_stacks_reorders_axes():
         descriptors.ATLAS_ORIENTATION, arr, copy=True
     )
     assert np.array_equal(result[0], expected)
+
+
+# --- _check_annotation_dtype ---
+
+
+def test_check_annotation_dtype_allows_safe_cast():
+    """Test `_check_annotation_dtype` accepts a dtype that fits in uint32."""
+    _check_annotation_dtype([np.zeros((2, 2, 2), dtype=np.uint16)])
+
+
+def test_check_annotation_dtype_allows_in_range_integers():
+    """Test `_check_annotation_dtype` accepts int64 labels within range."""
+    _check_annotation_dtype([np.arange(8, dtype=np.int64).reshape((2, 2, 2))])
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        pytest.param(np.zeros((2, 2, 2), dtype=np.float64), id="float"),
+        pytest.param(np.full((2, 2, 2), -1, dtype=np.int64), id="negative"),
+        pytest.param(
+            np.full((2, 2, 2), 2**32, dtype=np.int64), id="above uint32 max"
+        ),
+    ],
+)
+def test_check_annotation_dtype_invalid(annotation):
+    """Test `_check_annotation_dtype` rejects labels that do not fit uint32.
+
+    Parameters
+    ----------
+    annotation : np.ndarray
+        An annotation stack that cannot be stored as uint32 without loss.
+    """
+    with pytest.raises(ValueError, match="uint32"):
+        _check_annotation_dtype([annotation])
+
+
+def test_check_annotation_dtype_checks_every_scale():
+    """Test `_check_annotation_dtype` checks all scales, not just the first."""
+    stacks = [
+        np.zeros((4, 4, 4), dtype=np.uint32),
+        np.zeros((2, 2, 2), dtype=np.float64),
+    ]
+    with pytest.raises(ValueError, match="uint32"):
+        _check_annotation_dtype(stacks)
 
 
 # --- ComponentInfo ---
@@ -884,6 +930,28 @@ def test_atlas_packaging_data_additional_references_processed(
     assert isinstance(ref_stack, list)
     assert ref_stack[0].shape == (4, 4, 4)
     assert mock_check.call_count == 5
+
+
+def test_atlas_packaging_data_rejects_float_annotation(
+    mocker, atlas_packaging_kwargs
+):
+    """Test AtlasPackagingData rejects a float annotation stack up front.
+
+    Parameters
+    ----------
+    mocker : pytest_mock.MockerFixture
+        Mocker fixture for patching.
+    atlas_packaging_kwargs : dict
+        Minimal valid kwargs for AtlasPackagingData.
+    """
+    mocker.patch(
+        "brainglobe_atlasapi.atlas_generation.atlas_packaging_data.check_requested_component"
+    )
+    atlas_packaging_kwargs["annotation_stack"] = np.zeros(
+        (4, 4, 4), dtype=np.float64
+    )
+    with pytest.raises(ValueError, match="uint32"):
+        AtlasPackagingData(**atlas_packaging_kwargs)
 
 
 def test_atlas_packaging_data_multiscale_resolution(


### PR DESCRIPTION
Packaging an atlas whose annotation stack is not uint32 dies with a numba TypingError about contains(DictType[uint32,uint32], float64). It happens inside 4D mask generation, after the meshes and the precomputed annotations have been written, so a run can burn several minutes before failing on something that reads like an internal bug rather than a problem with the input data.

This checks the annotation dtype in AtlasPackagingData.__post_init__, which is the first thing wrapup_atlas_from_data does. A float stack, or an integer stack with values outside the uint32 range, now raises a ValueError naming the dtype, the allowed range and the cast to apply. Integer stacks whose values already fit in uint32 still pass, so scripts that hand over int32 or int64 labels keep working as they do today.

Tests are in tests/atlasgen/test_atlas_packaging_data.py, covering the helper directly and the float case through AtlasPackagingData.

Closes #865. I used Claude Code to help write this.