### PR TITLE
Add nested metadata structure validation (part 2 of #782)

### DIFF
--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -607,6 +607,114 @@ def validate_metadata(atlas: BrainGlobeAtlas):
     return True
 
 
+def _validate_component_metadata_shape(
+    component: dict, label: str, nested_keys: tuple[str, ...] = ()
+) -> bool:
+    """Validate that a component metadata dict has the expected shape.
+
+    Recursively checks that `component` is a dict containing `name`,
+    `version`, and `location` keys of type `str`, and that any sub-dicts
+    named in `nested_keys` are themselves present and have the same
+    three-key shape.
+
+    Parameters
+    ----------
+    component : dict
+        The component metadata dict to validate (e.g.
+        `atlas.metadata["template"]`).
+    label : str
+        A human-readable label for `component`, used in assertion
+        messages (e.g. "template", "annotation_set.template").
+    nested_keys : tuple of str, optional
+        Names of sub-dicts within `component` that should be recursively
+        validated against the same three-key shape. By default, empty.
+
+    Returns
+    -------
+    bool
+        True if `component` and any nested sub-dicts have the expected
+        shape.
+
+    Raises
+    ------
+    AssertionError
+        If `component` is not a dict, is missing a required key, a key
+        has the wrong type, or a nested sub-dict fails the same checks.
+    """
+    assert isinstance(
+        component, dict
+    ), f"{label} should be a dict, but got {type(component).__name__}."
+
+    for key in ("name", "version", "location"):
+        assert key in component, f"{label} is missing key: {key}"
+        assert isinstance(component[key], str), (
+            f"{label}.{key} should be of type str, "
+            f"but got {type(component[key]).__name__}."
+        )
+
+    for nested_key in nested_keys:
+        assert nested_key in component, f"{label} is missing key: {nested_key}"
+        _validate_component_metadata_shape(
+            component[nested_key], f"{label}.{nested_key}"
+        )
+
+    return True
+
+
+def validate_nested_metadata_structure(atlas: BrainGlobeAtlas) -> bool:
+    """Validate the nested component metadata structure of the atlas.
+
+    Checks that `atlas.metadata` contains `template`, `annotation_set`,
+    `terminology`, and `coordinate_space` entries, that each is a dict
+    with `name`, `version`, and `location` string keys, that
+    `annotation_set` additionally contains `template` and `terminology`
+    sub-dicts of the same shape, and that `coordinate_space` additionally
+    contains a `template` sub-dict of the same shape.
+
+    Parameters
+    ----------
+    atlas : BrainGlobeAtlas
+        The BrainGlobeAtlas object to validate.
+
+    Returns
+    -------
+    bool
+        True if the nested metadata structure adheres to the expected
+        shape.
+
+    Raises
+    ------
+    AssertionError
+        If a required component is missing from the metadata, is not a
+        dict, or is missing a required string key.
+    """
+    required_keys = (
+        "template",
+        "annotation_set",
+        "terminology",
+        "coordinate_space",
+    )
+    for key in required_keys:
+        assert key in atlas.metadata, f"atlas.metadata is missing key: {key}"
+
+    _validate_component_metadata_shape(atlas.metadata["template"], "template")
+    _validate_component_metadata_shape(
+        atlas.metadata["terminology"], "terminology"
+    )
+    _validate_component_metadata_shape(
+        atlas.metadata["annotation_set"],
+        "annotation_set",
+        nested_keys=("template", "terminology"),
+    )
+    _validate_component_metadata_shape(
+        atlas.metadata["coordinate_space"],
+        "coordinate_space",
+        nested_keys=("template",),
+    )
+
+    return True
+
+
 def report_validation_results(validation_results: dict) -> None:
     """
     Print a summary of atlas validation results.
@@ -664,6 +772,7 @@ def get_all_validation_functions():
         validate_unique_acronyms,
         validate_atlas_name,
         validate_atlas_name_listed,
+        validate_nested_metadata_structure,
     ]
 
 

--- a/brainglobe_atlasapi/atlas_generation/validate_atlases.py
+++ b/brainglobe_atlasapi/atlas_generation/validate_atlases.py
@@ -688,6 +688,11 @@ def validate_nested_metadata_structure(atlas: BrainGlobeAtlas) -> bool:
         If a required component is missing from the metadata, is not a
         dict, or is missing a required string key.
     """
+    assert isinstance(atlas.metadata, dict), (
+        "atlas.metadata should be a dict, but got "
+        f"{type(atlas.metadata).__name__}."
+    )
+
     required_keys = (
         "template",
         "annotation_set",

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -1,5 +1,6 @@
 """Test atlas validation functions."""
 
+import copy
 import os
 import re
 
@@ -21,6 +22,7 @@ from brainglobe_atlasapi.atlas_generation.validate_atlases import (
     validate_image_dimensions,
     validate_mesh_matches_image_extents,
     validate_metadata,
+    validate_nested_metadata_structure,
     validate_template_image_pixels,
     validate_unique_acronyms,
 )
@@ -523,6 +525,76 @@ def test_validate_metadata(atlas, metadata, expected_output, error_message):
             validate_metadata(atlas)
     else:
         assert validate_metadata(atlas) == expected_output
+
+
+def test_validate_nested_metadata_structure_passes(atlas):
+    """Verify `validate_nested_metadata_structure` passes for a valid atlas.
+
+    Parameters
+    ----------
+    atlas : BrainGlobeAtlas
+        A valid BrainGlobeAtlas instance.
+    """
+    assert validate_nested_metadata_structure(atlas)
+
+
+@pytest.mark.parametrize(
+    ["metadata_transform", "expected_error_message"],
+    [
+        pytest.param(
+            lambda metadata: metadata.pop("coordinate_space"),
+            r"atlas\.metadata is missing key: coordinate_space",
+            id="missing top-level component",
+        ),
+        pytest.param(
+            lambda metadata: metadata.update(
+                {"terminology": ["not", "a", "dict"]}
+            ),
+            r"terminology should be a dict, but got list\.",
+            id="component not a dict",
+        ),
+        pytest.param(
+            lambda metadata: metadata["template"].pop("location"),
+            r"template is missing key: location",
+            id="missing location key",
+        ),
+        pytest.param(
+            lambda metadata: metadata["coordinate_space"].update(
+                {"version": 3.0}
+            ),
+            r"coordinate_space\.version should be of type str, "
+            r"but got float\.",
+            id="key with non-str value",
+        ),
+        pytest.param(
+            lambda metadata: metadata["annotation_set"].pop("terminology"),
+            r"annotation_set is missing key: terminology",
+            id="missing nested sub-dict in annotation_set",
+        ),
+    ],
+)
+def test_validate_nested_metadata_structure_negative(
+    atlas, metadata_transform, expected_error_message
+):
+    """Verify `validate_nested_metadata_structure` fails with a message
+    identifying the failing key for various malformed metadata structures.
+
+    Parameters
+    ----------
+    atlas : BrainGlobeAtlas
+        A BrainGlobeAtlas instance.
+    metadata_transform : callable
+        Function that mutates a deep copy of `atlas.metadata` in place
+        to introduce a specific structural fault.
+    expected_error_message : str
+        Regex matching the expected AssertionError message.
+    """
+    mutated_metadata = copy.deepcopy(atlas.metadata)
+    metadata_transform(mutated_metadata)
+    atlas.metadata = mutated_metadata
+
+    with pytest.raises(AssertionError, match=expected_error_message):
+        validate_nested_metadata_structure(atlas)
 
 
 def test_validate_unique_acronyms_fail(mocker, atlas):

--- a/tests/atlasgen/test_validation.py
+++ b/tests/atlasgen/test_validation.py
@@ -597,6 +597,49 @@ def test_validate_nested_metadata_structure_negative(
         validate_nested_metadata_structure(atlas)
 
 
+@pytest.mark.parametrize(
+    ["metadata", "expected_type_name"],
+    [
+        pytest.param(None, "NoneType", id="metadata is None"),
+        pytest.param(
+            ["template", "annotation_set", "terminology", "coordinate_space"],
+            "list",
+            id="metadata is a list of the expected key names",
+        ),
+        pytest.param(
+            "template annotation_set terminology coordinate_space",
+            "str",
+            id="metadata is a string containing the expected key names",
+        ),
+    ],
+)
+def test_validate_nested_metadata_structure_non_dict_metadata(
+    atlas, metadata, expected_type_name
+):
+    """Verify `validate_nested_metadata_structure` fails with a message
+    naming the actual type when `atlas.metadata` is not a dict.
+
+    The list and string cases both contain the expected key names, so a
+    plain membership test would wrongly report them as present.
+
+    Parameters
+    ----------
+    atlas : BrainGlobeAtlas
+        A BrainGlobeAtlas instance.
+    metadata : object
+        A non-dict value to assign to `atlas.metadata`.
+    expected_type_name : str
+        The type name expected to appear in the AssertionError message.
+    """
+    atlas.metadata = metadata
+
+    expected_error_message = re.escape(
+        f"atlas.metadata should be a dict, but got {expected_type_name}."
+    )
+    with pytest.raises(AssertionError, match=expected_error_message):
+        validate_nested_metadata_structure(atlas)
+
+
 def test_validate_unique_acronyms_fail(mocker, atlas):
     """Check that an atlas with duplicate acronyms fails validation.
 


### PR DESCRIPTION
---

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Second of three PRs for #782. `validate_metadata` only checks the ten flat top-level keys in `METADATA_TEMPLATE`, so nothing currently validates the nested component structure introduced in #769. `validate_atlas_files` reaches into `metadata["template"]["location"]` and friends to build paths, but a missing or malformed component dict there surfaces as a `KeyError` or `TypeError` rather than a clear validation failure.

**What does this PR do?**

Adds `validate_nested_metadata_structure`, which checks that `atlas.metadata` contains `template`, `annotation_set`, `terminology` and `coordinate_space`, that each is a dict with `name`, `version` and `location` string keys, and that the sub-dicts embedded in `annotation_set` (`template`, `terminology`) and `coordinate_space` (`template`) have the same shape. A recursive private helper handles the shared shape, and assertion messages use dotted labels (`annotation_set.template.version`) so failures point at the exact location.

I validated the expected shape against `ComponentInfo.generate_metadata_dict()` in `atlas_packaging_data.py` rather than the `format_*_stub` descriptors, since those three appear to be uncalled (raised on #782).

Two things I left alone but am happy to change:

- `validate_metadata` and this function now both validate metadata, one flat and one nested. I kept them separate so this PR doesn't modify an existing validator, but they could be merged.
- I haven't made `validate_atlas_files` use this, so a malformed component dict there still raises `KeyError` rather than a clean assertion. That felt closer to the PR 3 scope.

## References

Part 2 of 3 for #782. Independent of #879 (part 1), since they touch different functions and can merge in either order.

## How has this PR been tested?

Six new tests in `tests/atlasgen/test_validation.py`: one asserting the real `kim_dev_mouse_e11-5_mri-adc_31.5um` fixture passes, and five parametrized negative cases covering a missing top-level component, a component that isn't a dict, a missing `location` key, a non-`str` `version`, and a missing nested sub-dict. Each negative case deep-copies the metadata before mutating it and asserts the error message identifies the failing key.

Full suite: 340 passed, 5 xfailed (334 before, plus the 6 new tests). The 5 xfails are unchanged.

## Is this a breaking change?

No. The new validator passes against the existing test atlas.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes. Not applicable.
- [x] The code has been formatted with [[pre-commit](https://pre-commit.com/)](https://pre-commit.com/)

---