### PR TITLE
Add lazy dask atlas loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ print(hemispheres_image.shape)
 # (528, 320, 456)
 ```
 
+Pass `lazy=True` to `BrainGlobeAtlas` to return dask arrays for these images; index/slice them as usual, then call `.compute()` when you need the numpy result.
+
 #### Brain regions
 
 There are multiple ways to work with individual brain regions. To see a dataframe of each brain region, with it's unique ID, acronym and full name, use `atlas.lookup_df`:

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -54,8 +54,8 @@ def _version_str_from_tuple(version_tuple: Tuple[int, ...]) -> str:
 
 
 class BrainGlobeAtlas(
-    core.Atlas[core.ReferenceArray, core.AnnotationArray, core.LabelArray],
-    Generic[core.ReferenceArray, core.AnnotationArray, core.LabelArray],
+    core.Atlas[core.TemplateArray, core.AnnotationArray, core.LabelArray],
+    Generic[core.TemplateArray, core.AnnotationArray, core.LabelArray],
 ):
     """Add remote atlas fetching and version comparison functionalities
     to the core Atlas class.

--- a/brainglobe_atlasapi/bg_atlas.py
+++ b/brainglobe_atlasapi/bg_atlas.py
@@ -1,11 +1,24 @@
 """Defines the BrainGlobe Atlas API V3 classes and functions."""
 
+from __future__ import annotations
+
 import re
 from collections.abc import Callable
 from io import StringIO
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import (
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
+import dask.array as da
+import numpy as np
+import numpy.typing as npt
 import s3fs
 from fsspec.callbacks import TqdmCallback
 from rich import print as rprint
@@ -40,7 +53,10 @@ def _version_str_from_tuple(version_tuple: Tuple[int, ...]) -> str:
     return "_".join(str(num) for num in version_tuple)
 
 
-class BrainGlobeAtlas(core.Atlas):
+class BrainGlobeAtlas(
+    core.Atlas[core.ReferenceArray, core.AnnotationArray, core.LabelArray],
+    Generic[core.ReferenceArray, core.AnnotationArray, core.LabelArray],
+):
     """Add remote atlas fetching and version comparison functionalities
     to the core Atlas class.
 
@@ -59,7 +75,54 @@ class BrainGlobeAtlas(core.Atlas):
     fn_update : Callable
         Handler function to update during download. Takes completed and total
         bytes.
+    lazy : bool
+        If True, atlas array properties return dask arrays instead of loading
+        them into memory as numpy arrays.
     """
+
+    @overload
+    def __init__(
+        self: BrainGlobeAtlas[
+            npt.NDArray[np.uint16],
+            npt.NDArray[np.uint32],
+            npt.NDArray[np.uint8],
+        ],
+        atlas_name: AtlasName,
+        version: Optional[str] = None,
+        brainglobe_dir: Optional[Union[str, Path]] = None,
+        check_latest: bool = True,
+        config_dir: Optional[Union[str, Path]] = None,
+        fn_update: Optional[Callable] = None,
+        lazy: Literal[False] = False,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: BrainGlobeAtlas[da.Array, da.Array, da.Array],
+        atlas_name: AtlasName,
+        version: Optional[str] = None,
+        brainglobe_dir: Optional[Union[str, Path]] = None,
+        check_latest: bool = True,
+        config_dir: Optional[Union[str, Path]] = None,
+        fn_update: Optional[Callable] = None,
+        lazy: Literal[True] = True,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: BrainGlobeAtlas[
+            Union[npt.NDArray[np.uint16], da.Array],
+            Union[npt.NDArray[np.uint32], da.Array],
+            Union[npt.NDArray[np.uint8], da.Array],
+        ],
+        atlas_name: AtlasName,
+        version: Optional[str] = None,
+        brainglobe_dir: Optional[Union[str, Path]] = None,
+        check_latest: bool = True,
+        config_dir: Optional[Union[str, Path]] = None,
+        fn_update: Optional[Callable] = None,
+        lazy: bool = False,
+    ) -> None: ...
 
     def __init__(
         self,
@@ -69,6 +132,7 @@ class BrainGlobeAtlas(core.Atlas):
         check_latest: bool = True,
         config_dir: Optional[Union[str, Path]] = None,
         fn_update: Optional[Callable] = None,
+        lazy: bool = False,
     ):
         self._remote_version = None
         self._local_full_name = None
@@ -113,7 +177,7 @@ class BrainGlobeAtlas(core.Atlas):
                     "download."
                 )
 
-        super().__init__(self.brainglobe_dir / self.local_full_name)
+        super().__init__(self.brainglobe_dir / self.local_full_name, lazy=lazy)
 
         if check_latest:
             self.check_latest_version()

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -44,8 +44,8 @@ from brainglobe_atlasapi.utils import (
     read_json,
 )
 
-ReferenceArray = TypeVar(
-    "ReferenceArray", bound=Union[npt.NDArray[np.uint16], da.Array]
+TemplateArray = TypeVar(
+    "TemplateArray", bound=Union[npt.NDArray[np.uint16], da.Array]
 )
 AnnotationArray = TypeVar(
     "AnnotationArray", bound=Union[npt.NDArray[np.uint32], da.Array]
@@ -98,7 +98,7 @@ def _determine_pyramid_level(
     raise ValueError(f"Requested resolution {resolution} um is invalid.")
 
 
-class Atlas(Generic[ReferenceArray, AnnotationArray, LabelArray]):
+class Atlas(Generic[TemplateArray, AnnotationArray, LabelArray]):
     """Base class to handle atlases in BrainGlobe.
 
     Parameters
@@ -278,10 +278,10 @@ class Atlas(Generic[ReferenceArray, AnnotationArray, LabelArray]):
         return self._lookup
 
     @property
-    def template(self) -> ReferenceArray:
+    def template(self) -> TemplateArray:
         """Return the template image data. Loads it if not already loaded."""
         if self._template is not None:
-            return cast(ReferenceArray, self._template)
+            return cast(TemplateArray, self._template)
 
         template_location = self.metadata["annotation_set"]["template"][
             "location"
@@ -310,7 +310,7 @@ class Atlas(Generic[ReferenceArray, AnnotationArray, LabelArray]):
         data = multiscale.images[self._template_pyramid_level].data
         self._template = data if self.lazy else data.compute()
 
-        return cast(ReferenceArray, self._template)
+        return cast(TemplateArray, self._template)
 
     @property
     def reference(self):

--- a/brainglobe_atlasapi/core.py
+++ b/brainglobe_atlasapi/core.py
@@ -1,15 +1,23 @@
 """Module containing the core Atlas class."""
 
+from __future__ import annotations
+
 import warnings
 from collections import UserDict, deque
 from pathlib import Path
 from typing import (
     Dict,
+    Generic,
     List,
+    Literal,
     Tuple,
+    TypeVar,
     Union,
+    cast,
+    overload,
 )
 
+import dask.array as da
 import ngff_zarr as nz
 import numpy as np
 import numpy.typing as npt
@@ -20,9 +28,7 @@ from brainglobe_space import AnatomicalSpace
 from fsspec.callbacks import TqdmCallback
 
 from brainglobe_atlasapi.descriptors import (
-    ANNOTATION_DTYPE,
     ATLAS_ORIENTATION,
-    REFERENCE_DTYPE,
     V3_ANNOTATION_MAP_NAME,
     V3_ANNOTATION_MASKS_NAME,
     V3_ANNOTATION_NAME,
@@ -36,6 +42,16 @@ from brainglobe_atlasapi.structure_class import StructuresDict
 from brainglobe_atlasapi.utils import (
     load_structures_from_csv,
     read_json,
+)
+
+ReferenceArray = TypeVar(
+    "ReferenceArray", bound=Union[npt.NDArray[np.uint16], da.Array]
+)
+AnnotationArray = TypeVar(
+    "AnnotationArray", bound=Union[npt.NDArray[np.uint32], da.Array]
+)
+LabelArray = TypeVar(
+    "LabelArray", bound=Union[npt.NDArray[np.uint8], da.Array]
 )
 
 
@@ -82,19 +98,52 @@ def _determine_pyramid_level(
     raise ValueError(f"Requested resolution {resolution} um is invalid.")
 
 
-class Atlas:
+class Atlas(Generic[ReferenceArray, AnnotationArray, LabelArray]):
     """Base class to handle atlases in BrainGlobe.
 
     Parameters
     ----------
     path : str or Path object
         Path to folder containing data info.
+    lazy : bool
+        If True, atlas array properties return dask arrays instead of loading
+        them into memory as numpy arrays.
     """
 
     left_hemisphere_value = 1
     right_hemisphere_value = 2
 
-    def __init__(self, path):
+    @overload
+    def __init__(
+        self: Atlas[
+            npt.NDArray[np.uint16],
+            npt.NDArray[np.uint32],
+            npt.NDArray[np.uint8],
+        ],
+        path: Union[str, Path],
+        lazy: Literal[False] = False,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: Atlas[da.Array, da.Array, da.Array],
+        path: Union[str, Path],
+        lazy: Literal[True] = True,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: Atlas[
+            Union[npt.NDArray[np.uint16], da.Array],
+            Union[npt.NDArray[np.uint32], da.Array],
+            Union[npt.NDArray[np.uint8], da.Array],
+        ],
+        path: Union[str, Path],
+        lazy: bool = False,
+    ) -> None: ...
+
+    def __init__(self, path: Union[str, Path], lazy: bool = False):
+        self.lazy = lazy
         self._template_pyramid_level = 0
         self._annotation_pyramid_level = 0
         self.fs = s3fs.S3FileSystem(anon=True)
@@ -229,10 +278,10 @@ class Atlas:
         return self._lookup
 
     @property
-    def template(self) -> npt.NDArray[REFERENCE_DTYPE]:
+    def template(self) -> ReferenceArray:
         """Return the template image data. Loads it if not already loaded."""
         if self._template is not None:
-            return self._template
+            return cast(ReferenceArray, self._template)
 
         template_location = self.metadata["annotation_set"]["template"][
             "location"
@@ -258,11 +307,10 @@ class Atlas:
                 callback=TqdmCallback(),
             )
 
-        self._template = multiscale.images[
-            self._template_pyramid_level
-        ].data.compute()
+        data = multiscale.images[self._template_pyramid_level].data
+        self._template = data if self.lazy else data.compute()
 
-        return self._template
+        return cast(ReferenceArray, self._template)
 
     @property
     def reference(self):
@@ -278,10 +326,10 @@ class Atlas:
         return self.template
 
     @property
-    def annotation(self) -> npt.NDArray[ANNOTATION_DTYPE]:
+    def annotation(self) -> AnnotationArray:
         """Return the annotation image data. Loads it if not already loaded."""
         if self._annotation is not None:
-            return self._annotation
+            return cast(AnnotationArray, self._annotation)
 
         annotation_location = self.metadata["annotation_set"]["location"][1:]
         annotation_path = (
@@ -306,14 +354,13 @@ class Atlas:
                 callback=TqdmCallback(),
             )
 
-        self._annotation = multiscale.images[
-            self._annotation_pyramid_level
-        ].data.compute()
+        data = multiscale.images[self._annotation_pyramid_level].data
+        self._annotation = data if self.lazy else data.compute()
 
-        return self._annotation
+        return cast(AnnotationArray, self._annotation)
 
     @property
-    def hemispheres(self):
+    def hemispheres(self) -> LabelArray:
         """
         Returns a stack with the hemisphere information. 1 - left, 2 - right.
 
@@ -323,24 +370,43 @@ class Atlas:
         the middle plane is assigned to the left hemisphere.
         """
         if self._hemispheres is not None:
-            return self._hemispheres
+            return cast(LabelArray, self._hemispheres)
 
         # If reference is symmetric generate hemispheres block:
         if self.metadata["symmetric"]:
-            # initialize empty stack:
-            stack = np.full(self.metadata["shape"], 2, dtype=np.uint8)
-
-            # Use bgspace description to fill out with hemisphere values:
+            shape = tuple(self.metadata["shape"])
             front_ax_idx = self.space.axes_order.index("frontal")
+            split = round(shape[front_ax_idx] / 2)
 
-            # Fill out with 2s the right hemisphere:
-            slices = [slice(None) for _ in range(3)]
-            slices[front_ax_idx] = slice(
-                round(stack.shape[front_ax_idx] / 2), None
-            )
-            stack[tuple(slices)] = 1
+            if self.lazy:
+                right_shape = list(shape)
+                right_shape[front_ax_idx] = split
+                left_shape = list(shape)
+                left_shape[front_ax_idx] -= split
+                self._hemispheres = da.concatenate(
+                    [
+                        da.full(
+                            right_shape,
+                            self.right_hemisphere_value,
+                            dtype=np.uint8,
+                        ),
+                        da.full(
+                            left_shape,
+                            self.left_hemisphere_value,
+                            dtype=np.uint8,
+                        ),
+                    ],
+                    axis=front_ax_idx,
+                )
+            else:
+                stack = np.full(
+                    shape, self.right_hemisphere_value, dtype=np.uint8
+                )
+                slices = [slice(None) for _ in range(3)]
+                slices[front_ax_idx] = slice(split, None)
+                stack[tuple(slices)] = self.left_hemisphere_value
 
-            self._hemispheres = stack
+                self._hemispheres = stack
         else:
             annotation_location = self.metadata["annotation_set"]["location"][
                 1:
@@ -367,11 +433,10 @@ class Atlas:
                     callback=TqdmCallback(),
                 )
 
-            self._hemispheres = multiscale.images[
-                self._annotation_pyramid_level
-            ].data.compute()
+            data = multiscale.images[self._annotation_pyramid_level].data
+            self._hemispheres = data if self.lazy else data.compute()
 
-        return self._hemispheres
+        return cast(LabelArray, self._hemispheres)
 
     def hemisphere_from_coords(
         self,
@@ -399,6 +464,8 @@ class Atlas:
 
         """
         hem = self.hemispheres[self._idx_from_coords(coords, microns)]
+        if self.lazy:
+            hem = int(hem.compute())
         if as_string:
             hem = ["left", "right"][hem - 1]
         return hem
@@ -432,6 +499,8 @@ class Atlas:
             Structure containing the coordinates.
         """
         rid = self.annotation[self._idx_from_coords(coords, microns)]
+        if self.lazy:
+            rid = int(rid.compute())
 
         # If we want to cut the result at some high level of the hierarchy:
         if hierarchy_lev is not None:
@@ -693,7 +762,7 @@ class Atlas:
             return [self.structures[sid]["acronym"] for sid in result]
         return result
 
-    def get_structure_mask(self, structure) -> npt.NDArray[np.uint8]:
+    def get_structure_mask(self, structure) -> LabelArray:
         """Return binary uint8 mask for the given structure.
 
         Reads directly from the pre-built 4D annotation masks array.
@@ -758,11 +827,10 @@ class Atlas:
                     f"not found at {remote_path}"
                 ) from e
 
-        return (
-            multiscale.images[self._annotation_masks_pyramid_level]
-            .data[index]
-            .compute()
-        )
+        data = multiscale.images[self._annotation_masks_pyramid_level].data[
+            index
+        ]
+        return cast(LabelArray, data if self.lazy else data.compute())
 
 
 class AdditionalRefDict(UserDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "aiobotocore >= 3.6.0",
     "brainglobe-space >= 1.0.0",
     "click",
+    "dask[array]",
     "DracoPy",
     "fsspec",
     "meshio",

--- a/tests/atlasapi/test_core_atlas_lazy.py
+++ b/tests/atlasapi/test_core_atlas_lazy.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import dask.array as da
 import numpy as np
+import pytest
 
 from brainglobe_atlasapi import BrainGlobeAtlas, core
 
@@ -51,18 +52,23 @@ def _atlas(tmp_path, monkeypatch, data):
     return atlas
 
 
-def test_example_atlas_lazy_properties_are_dask_arrays(atlas):
+@pytest.mark.parametrize(
+    "stack_name, val",
+    [
+        ("template", [[[155, 146], [157, 153]], [[151, 148], [154, 153]]]),
+        ("annotation", [[[59, 59], [59, 59]], [[59, 59], [59, 59]]]),
+        ("hemispheres", [[[2, 1], [2, 1]], [[2, 1], [2, 1]]]),
+    ],
+)
+def test_example_atlas_lazy_properties_are_dask_arrays(atlas, stack_name, val):
     """BrainGlobeAtlas(..., lazy=True) works on the example atlas."""
     lazy_atlas = BrainGlobeAtlas(
         atlas.atlas_name, check_latest=False, lazy=True
     )
+    loaded_stack = getattr(lazy_atlas, stack_name)
 
-    assert isinstance(lazy_atlas.template, da.Array)
-    assert isinstance(lazy_atlas.annotation, da.Array)
-    assert isinstance(lazy_atlas.hemispheres, da.Array)
-    assert lazy_atlas.template[65, 39, 56].compute() == 155
-    assert lazy_atlas.annotation[65, 39, 56].compute() == 59
-    assert lazy_atlas.hemispheres[65, 39, 56].compute() == 2
+    assert isinstance(loaded_stack, da.Array)
+    assert np.allclose(loaded_stack[65:67, 39:41, 56:58].compute(), val)
 
 
 def test_lazy_coord_lookups_return_scalars(tmp_path, monkeypatch):

--- a/tests/atlasapi/test_core_atlas_lazy.py
+++ b/tests/atlasapi/test_core_atlas_lazy.py
@@ -1,0 +1,102 @@
+"""Test lazy atlas array loading."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import dask.array as da
+import numpy as np
+
+from brainglobe_atlasapi import BrainGlobeAtlas, core
+
+
+def _multiscale(data):
+    """Build a tiny ngff-zarr-like multiscale object."""
+    return SimpleNamespace(
+        images=[SimpleNamespace(data=data)],
+        metadata=SimpleNamespace(datasets=[SimpleNamespace(path="s0")]),
+    )
+
+
+def _atlas(tmp_path, monkeypatch, data):
+    """Build a minimal Atlas instance without running full init."""
+    atlas = object.__new__(core.Atlas)
+    atlas.lazy = True
+    atlas.root_dir = tmp_path
+    atlas.metadata = {
+        "annotation_set": {
+            "template": {"location": "/template"},
+            "location": "/annotation",
+        },
+        "shape": [2, 2, 2],
+        "symmetric": True,
+    }
+    atlas.space = SimpleNamespace(
+        axes_order=["superior", "anterior", "frontal"]
+    )
+    atlas.fs = MagicMock()
+    atlas._template = None
+    atlas._annotation = None
+    atlas._hemispheres = None
+    atlas._template_pyramid_level = 0
+    atlas._annotation_pyramid_level = 0
+    atlas._annotation_masks_pyramid_level = 0
+    atlas._annotation_mapping = {2: 0}
+    atlas.structures = {
+        "leaf": {"id": 2},
+        2: {"id": 2, "acronym": "leaf", "structure_id_path": [2]},
+    }
+    monkeypatch.setattr(
+        core.nz, "from_ngff_zarr", lambda path: _multiscale(data)
+    )
+    return atlas
+
+
+def test_lazy_properties_return_dask_arrays(tmp_path, monkeypatch):
+    """lazy=True returns dask arrays for atlas volume components."""
+    data = da.from_array(np.arange(8, dtype=np.uint8).reshape(2, 2, 2))
+    atlas = _atlas(tmp_path, monkeypatch, data)
+
+    assert isinstance(atlas.template, da.Array)
+    assert isinstance(atlas.annotation, da.Array)
+    assert isinstance(atlas.hemispheres, da.Array)
+    assert atlas.template.compute()[0, 0, 1] == 1
+    assert atlas.annotation.compute()[0, 1, 0] == 2
+    assert atlas.hemispheres.compute()[0, 0, 1] == atlas.left_hemisphere_value
+
+
+def test_example_atlas_lazy_properties_are_dask_arrays(atlas):
+    """BrainGlobeAtlas(..., lazy=True) works on the example atlas."""
+    lazy_atlas = BrainGlobeAtlas(
+        atlas.atlas_name, check_latest=False, lazy=True
+    )
+
+    assert isinstance(lazy_atlas.template, da.Array)
+    assert isinstance(lazy_atlas.annotation, da.Array)
+    assert isinstance(lazy_atlas.hemispheres, da.Array)
+    assert lazy_atlas.template[65, 39, 56].compute() == 155
+    assert lazy_atlas.annotation[65, 39, 56].compute() == 59
+    assert lazy_atlas.hemispheres[65, 39, 56].compute() == 2
+
+
+def test_lazy_coord_lookups_return_scalars(tmp_path, monkeypatch):
+    """lazy=True keeps coordinate helper return values eager/scalar."""
+    data = da.from_array(np.full((2, 2, 2), 2, dtype=np.uint8))
+    atlas = _atlas(tmp_path, monkeypatch, data)
+
+    structure = atlas.structure_from_coords((0, 0, 0))
+
+    assert isinstance(structure, int)
+    assert structure == 2
+    assert atlas.structure_from_coords((0, 0, 0), as_acronym=True) == "leaf"
+    assert atlas.hemisphere_from_coords((0, 0, 1), as_string=True) == "left"
+
+
+def test_lazy_get_structure_mask_returns_dask_array(tmp_path, monkeypatch):
+    """lazy=True returns a dask array for structure masks."""
+    data = da.from_array(np.ones((1, 2, 2, 2), dtype=np.uint8))
+    atlas = _atlas(tmp_path, monkeypatch, data)
+
+    mask = atlas.get_structure_mask("leaf")
+
+    assert isinstance(mask, da.Array)
+    assert mask.compute()[0, 0, 0] == 1

--- a/tests/atlasapi/test_core_atlas_lazy.py
+++ b/tests/atlasapi/test_core_atlas_lazy.py
@@ -51,19 +51,6 @@ def _atlas(tmp_path, monkeypatch, data):
     return atlas
 
 
-def test_lazy_properties_return_dask_arrays(tmp_path, monkeypatch):
-    """lazy=True returns dask arrays for atlas volume components."""
-    data = da.from_array(np.arange(8, dtype=np.uint8).reshape(2, 2, 2))
-    atlas = _atlas(tmp_path, monkeypatch, data)
-
-    assert isinstance(atlas.template, da.Array)
-    assert isinstance(atlas.annotation, da.Array)
-    assert isinstance(atlas.hemispheres, da.Array)
-    assert atlas.template.compute()[0, 0, 1] == 1
-    assert atlas.annotation.compute()[0, 1, 0] == 2
-    assert atlas.hemispheres.compute()[0, 0, 1] == atlas.left_hemisphere_value
-
-
 def test_example_atlas_lazy_properties_are_dask_arrays(atlas):
     """BrainGlobeAtlas(..., lazy=True) works on the example atlas."""
     lazy_atlas = BrainGlobeAtlas(


### PR DESCRIPTION
Closes #882.

## Summary
- add `lazy=True` to `BrainGlobeAtlas`/core `Atlas`
- when `lazy=True`, return dask arrays for template, annotation, hemispheres, and structure masks
- make `Atlas`/`BrainGlobeAtlas` generic over array types for proper hints in IDEs and with static type checkers
- keep coordinate lookup methods returning scalar values