### PR TITLE
Add zarr dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "tifffile>=2018.11.6",
     "tqdm >= 4.46.1",
     "treelib",
-    "zarr>3"
+    "zarr>=3"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "tifffile>=2018.11.6",
     "tqdm >= 4.46.1",
     "treelib",
-    "zarr>=3"
+    "zarr>3"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "tifffile>=2018.11.6",
     "tqdm >= 4.46.1",
     "treelib",
+    "zarr>3"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
closes #951 as our atlases are only compatible with zarr 3.  

I have reproduced the error in the issue and confirmed this change fixes it.